### PR TITLE
Device fixes, resource metrics and rolling upgrades (#1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '20', cache: npm }
       - run: npm ci
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.25' }
+      - name: Build the Rusted backup engine (bundled so backups work out of the box)
+        continue-on-error: true   # optional - the .deb still installs (backups just unconfigured)
+        run: deploy/rusted/build-rusted.sh
       - name: Build the .deb
         run: VERSION="${GITHUB_REF_NAME#v}" deploy/build/build-deb.sh
       - uses: actions/upload-artifact@v4
@@ -45,6 +50,11 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '20', cache: npm }
       - run: npm ci
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.25' }
+      - name: Build the Rusted backup engine (bundled so backups work out of the box)
+        continue-on-error: true
+        run: deploy/rusted/build-rusted.sh
       - name: Install container tooling
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends podman zstd nftables passt
       - name: Build the .deb (input to the template)

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /storage/*.key
 /storage/pail
 /vendor
+/deploy/rusted/vendor
 _ide_helper.php
 Homestead.json
 Homestead.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && curl -fsSL https://github.com/schweikert/fping/releases/download/v5.5/fping-5.5.tar.gz | tar xz \
     && cd fping-5.5 && ./configure --prefix=/usr/local && make && make install
 
+# --- 2b. rusted backup engine (Go; the 1.26 toolchain is auto-fetched) --------
+FROM golang:1.24-bookworm AS rusted
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && git clone --depth 1 https://github.com/JoshFinlayAU/rusted.git /src
+WORKDIR /src
+RUN CGO_ENABLED=0 GOTOOLCHAIN=auto go build -trimpath -o /rusted ./cmd/rusted
+
 # --- 3. composer (named stage so `COPY --from=composer` works everywhere) -----
 FROM composer:2 AS composer
 
@@ -37,7 +44,7 @@ FROM php:8.4-fpm-bookworm AS runtime
 # in the base image).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        nginx supervisor tini postgresql-client procps libcap2-bin ca-certificates \
+        nginx supervisor tini postgresql-client procps libcap2-bin ca-certificates git \
     && rm -rf /var/lib/apt/lists/*
 
 # PHP extensions via the maintained installer - it pulls the right C libraries, builds redis
@@ -73,6 +80,11 @@ RUN composer dump-autoload --optimize --no-dev \
 COPY --from=assets /app/public/build ./public/build
 COPY --from=fping /usr/local/sbin/fping /usr/local/sbin/fping
 RUN setcap cap_net_raw+ep /usr/local/sbin/fping
+
+# Rusted backup engine + its data dirs (the entrypoint generates the config on first start).
+COPY --from=rusted /rusted /usr/local/bin/rusted
+RUN mkdir -p /var/lib/rusted/backups /etc/rusted \
+    && chown -R www-data:www-data /var/lib/rusted /etc/rusted
 
 # Container config + entrypoint.
 COPY docker/nginx.conf /etc/nginx/nginx.conf

--- a/app/Actions/Backup/ProvisionSshKey.php
+++ b/app/Actions/Backup/ProvisionSshKey.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Actions\Backup;
+
+use App\Models\Credential;
+use App\Models\Device;
+use App\Services\Backup\RustedClient;
+use RuntimeException;
+
+/**
+ * Bootstrap key-based SSH on a MikroTik so it can be backed up over SSH (RouterOS won't
+ * hand a config back over the API). Uses the device's RouterOS-API login to have Rusted
+ * install a generated key over the API, then stores the returned private key as a
+ * dedicated SSH credential on the device and points its backups at the SSH driver.
+ *
+ * Returns the provisioning result (ssh port/enabled state) so the UI can report it -
+ * notably whether Rusted had to enable the SSH service.
+ */
+class ProvisionSshKey
+{
+    public function __construct(private RustedClient $client) {}
+
+    /** @return array{user:string, ssh_port:int, ssh_enabled:bool, ssh_enabled_by:bool} */
+    public function __invoke(Device $device): array
+    {
+        $cred = $device->credential;
+        if ($cred === null || $cred->type !== 'routeros' || (string) $cred->username === '') {
+            throw new RuntimeException(
+                "'{$device->name}' needs a RouterOS API credential (username + password) to bootstrap SSH over the API.",
+            );
+        }
+
+        $result = $this->client->provisionMikrotikSshKey(
+            $device->mgmt_ip,
+            $cred->api_port ?: 8728,
+            (string) $cred->username,
+            (string) $cred->password,
+        );
+
+        // Store the private key as the device's SSH credential (reuse the existing one if
+        // this device was provisioned before, so we don't leave orphans behind).
+        $sshCred = $device->sshCredential;
+        if ($sshCred === null || $sshCred->type !== 'ssh') {
+            $sshCred = new Credential(['name' => "SSH (auto) - {$device->name} #{$device->id}"]);
+        }
+        $sshCred->type = 'ssh';
+        // The "+ct" login suffix tells RouterOS to disable console colours and terminal
+        // detection, so its SSH output is clean/script-friendly (without it the interactive
+        // shell returns an empty capture). It still authenticates as the base user + key.
+        $sshCred->username = $result['user'].'+ct';
+        $sshCred->password = '';
+        $sshCred->private_key = $result['private_key'];
+        $sshCred->save();
+
+        // Back this device up over SSH with the standard MikroTik driver from now on.
+        $device->forceFill([
+            'ssh_credential_id' => $sshCred->id,
+            'backup_driver' => 'mikrotik_routeros',
+        ])->save();
+
+        // Don't hand the private key back to the browser.
+        unset($result['private_key']);
+
+        return $result;
+    }
+}

--- a/app/Actions/Backup/RegisterBackupDevice.php
+++ b/app/Actions/Backup/RegisterBackupDevice.php
@@ -39,11 +39,16 @@ class RegisterBackupDevice
         [$credentialName, $credentialPayload] = $this->resolveCredential($device);
         $this->client->putCredential($credentialPayload);
 
+        // The RouterOS-API driver backs up over the binary API instead of SSH; pick the
+        // matching Rusted transport + default port for it.
+        $overApi = $driver === 'mikrotik_routeros_api';
+
         $this->client->putDevice([
             'name' => self::rustedName($device),
             'host' => $device->mgmt_ip,
-            'port' => (int) config('mymate.backup.ssh_port', 22),
+            'port' => $overApi ? 8728 : (int) config('mymate.backup.ssh_port', 22),
             'driver' => $driver,
+            'transport' => $overApi ? 'routeros-api' : '',
             'credential' => $credentialName,
             'group' => (string) config('mymate.backup.group', 'mymate'),
             'enabled' => (bool) $device->backup_enabled,

--- a/app/Actions/Backup/RegisterBackupDevice.php
+++ b/app/Actions/Backup/RegisterBackupDevice.php
@@ -13,11 +13,12 @@ use RuntimeException;
  * Rusted engine. Idempotent: called before every backup run so Rusted's
  * inventory always matches My Mate's (name, host, driver, enabled flag, credential).
  *
- * Credential resolution ("reuse device creds + a Settings fallback", the chosen model):
- *  1. the device's own My Mate credential if it carries an SSH-usable username/password
+ * Credential resolution (device-specific first, then a Settings fallback):
+ *  1. the device's dedicated SSH credential if set - pushed as `mymate-cred-{id}`;
+ *  2. else the device's own poll credential if it carries an SSH-usable username/password
  *     (RouterOS-API logins double as SSH logins) - pushed as `mymate-cred-{id}`;
- *  2. else the default SSH credential from Settings - pushed as `mymate-default`;
- *  3. else fail loudly - a backup can't run without a login.
+ *  3. else the default SSH credential from Settings - pushed as `mymate-default`;
+ *  4. else fail loudly - a backup can't run without a login.
  *
  * Secrets are only ever sent onward to the (localhost, trusted) Rusted API - never logged.
  */
@@ -60,16 +61,18 @@ class RegisterBackupDevice
      */
     private function resolveCredential(Device $device): array
     {
-        $cred = $device->credential;
+        // 1. a dedicated SSH credential wins; 2. else the poll credential if SSH-usable.
         // Accessing username/password triggers the model's `encrypted` cast (decrypt).
-        if ($cred !== null && (string) $cred->username !== '') {
-            return ["mymate-cred-{$cred->id}", [
-                'name' => "mymate-cred-{$cred->id}",
-                'username' => (string) $cred->username,
-                'password' => (string) $cred->password,
-                'enable' => '',
-                'private_key' => '',
-            ]];
+        foreach ([$device->sshCredential, $device->credential] as $cred) {
+            if ($cred !== null && (string) $cred->username !== '') {
+                return ["mymate-cred-{$cred->id}", [
+                    'name' => "mymate-cred-{$cred->id}",
+                    'username' => (string) $cred->username,
+                    'password' => (string) $cred->password,
+                    'enable' => '',
+                    'private_key' => '',
+                ]];
+            }
         }
 
         $fallback = $this->settings->defaultSshCredential();

--- a/app/Actions/Backup/RegisterBackupDevice.php
+++ b/app/Actions/Backup/RegisterBackupDevice.php
@@ -39,16 +39,11 @@ class RegisterBackupDevice
         [$credentialName, $credentialPayload] = $this->resolveCredential($device);
         $this->client->putCredential($credentialPayload);
 
-        // The RouterOS-API driver backs up over the binary API instead of SSH; pick the
-        // matching Rusted transport + default port for it.
-        $overApi = $driver === 'mikrotik_routeros_api';
-
         $this->client->putDevice([
             'name' => self::rustedName($device),
             'host' => $device->mgmt_ip,
-            'port' => $overApi ? 8728 : (int) config('mymate.backup.ssh_port', 22),
+            'port' => (int) config('mymate.backup.ssh_port', 22),
             'driver' => $driver,
-            'transport' => $overApi ? 'routeros-api' : '',
             'credential' => $credentialName,
             'group' => (string) config('mymate.backup.group', 'mymate'),
             'enabled' => (bool) $device->backup_enabled,
@@ -75,7 +70,8 @@ class RegisterBackupDevice
                     'username' => (string) $cred->username,
                     'password' => (string) $cred->password,
                     'enable' => '',
-                    'private_key' => '',
+                    // Key-based SSH (e.g. a key provisioned onto a MikroTik over the API).
+                    'private_key' => (string) $cred->private_key,
                 ]];
             }
         }

--- a/app/Actions/Devices/RunBulkUpgrade.php
+++ b/app/Actions/Devices/RunBulkUpgrade.php
@@ -24,10 +24,14 @@ class RunBulkUpgrade
         private UpgradePreflight $preflight,
     ) {}
 
-    /** @param list<int> $deviceIds */
-    public function __invoke(array $deviceIds): void
+    /**
+     * @param list<int> $deviceIds
+     * @param bool $preserveOrder keep the given order (operator re-ordered by hand) instead
+     *                            of re-sorting furthest-downstream-first
+     */
+    public function __invoke(array $deviceIds, bool $preserveOrder = false): void
     {
-        $plan = ($this->preflight)($deviceIds);
+        $plan = ($this->preflight)($deviceIds, $preserveOrder);
 
         // Mark skipped devices so their queued spinner clears with the reason.
         foreach ($plan['plan'] as $row) {

--- a/app/Actions/Devices/UpgradePreflight.php
+++ b/app/Actions/Devices/UpgradePreflight.php
@@ -5,16 +5,21 @@ namespace App\Actions\Devices;
 use App\Enums\DeviceStatus;
 use App\Enums\PollMethod;
 use App\Models\Device;
+use App\Models\Link;
 use App\Support\DeviceHierarchy;
 use Illuminate\Support\Collection;
 
 /**
- * Plan a bulk upgrade before running it: order the devices
- * downstream-first and decide which to upgrade vs skip - and why. Read-only; used
- * by the dry-run endpoint and by RunBulkUpgrade to mark skips up front.
+ * Plan a bulk upgrade before running it: order the devices downstream-first (furthest
+ * from the core first) and decide which to upgrade vs skip - and why. Read-only; used by
+ * the dry-run endpoint, the rolling-upgrades page (which also shows the topology context)
+ * and by RunBulkUpgrade to mark skips up front.
  *
  * Skip reasons: not a RouterOS device - device is down - parent is down (path
  * unreachable) - already up to date (latest is not newer than installed).
+ *
+ * When $preserveOrder is true the given order is kept as-is (the operator re-ordered the
+ * list by hand); otherwise it's sorted furthest-downstream-first.
  */
 class UpgradePreflight
 {
@@ -22,9 +27,9 @@ class UpgradePreflight
 
     /**
      * @param  list<int>  $deviceIds
-     * @return array{order: list<int>, upgrade: list<int>, plan: list<array{device_id:int, name:string, action:string, reason:?string}>}
+     * @return array{order: list<int>, upgrade: list<int>, plan: list<array{device_id:int, name:string, action:string, reason:?string, status:string, depth:int, os_version:?string, latest_version:?string, parent_name:?string, neighbours:list<string>}>}
      */
-    public function __invoke(array $deviceIds): array
+    public function __invoke(array $deviceIds, bool $preserveOrder = false): array
     {
         /** @var Collection<int, Device> $byId */
         $byId = Device::all()->keyBy('id');
@@ -34,7 +39,9 @@ class UpgradePreflight
             fn (int $id): bool => $byId->has($id),
         ));
 
-        $order = $this->hierarchy->orderDownstreamFirst($selected);
+        $order = $preserveOrder ? $selected : $this->hierarchy->orderDownstreamFirst($selected);
+        $depths = $this->hierarchy->depths();
+        $neighbours = $this->neighbours($byId);
 
         $plan = [];
         $upgrade = [];
@@ -42,11 +49,18 @@ class UpgradePreflight
             /** @var Device $device */
             $device = $byId->get($id);
             $reason = $this->skipReason($device, $byId);
+            $parent = $device->parent_device_id !== null ? $byId->get($device->parent_device_id) : null;
             $plan[] = [
                 'device_id' => $id,
                 'name' => $device->name,
                 'action' => $reason === null ? 'upgrade' : 'skip',
                 'reason' => $reason,
+                'status' => $device->status->value,
+                'depth' => $depths[$id] ?? 0,
+                'os_version' => $device->os_version,
+                'latest_version' => $device->latest_version,
+                'parent_name' => $parent?->name,
+                'neighbours' => array_values($neighbours[$id] ?? []),
             ];
             if ($reason === null) {
                 $upgrade[] = $id;
@@ -54,6 +68,30 @@ class UpgradePreflight
         }
 
         return ['order' => $order, 'upgrade' => $upgrade, 'plan' => $plan];
+    }
+
+    /**
+     * device_id => list of linked peer device names, so the UI can show what connects to
+     * what and the operator can eyeball which end is furthest out.
+     *
+     * @param  Collection<int, Device>  $byId
+     * @return array<int, list<string>>
+     */
+    private function neighbours(Collection $byId): array
+    {
+        $out = [];
+        foreach (Link::query()->select('a_device_id', 'b_device_id')->get() as $link) {
+            $a = (int) $link->a_device_id;
+            $b = (int) $link->b_device_id;
+            if (($nameB = $byId->get($b)?->name) !== null) {
+                $out[$a][$nameB] = $nameB;
+            }
+            if (($nameA = $byId->get($a)?->name) !== null) {
+                $out[$b][$nameA] = $nameA;
+            }
+        }
+
+        return array_map('array_values', $out);
     }
 
     /** @param  Collection<int, Device>  $byId */

--- a/app/Actions/History/GetDeviceMetricSamples.php
+++ b/app/Actions/History/GetDeviceMetricSamples.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Actions\History;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Bucketed/downsampled cpu/mem/temp history for one device over [from, to). Mirrors
+ * GetInterfaceSamples: the bucket width targets ~`history.max_points` points regardless
+ * of window, each bucket averaged via Postgres `date_bin` (PG14+).
+ */
+class GetDeviceMetricSamples
+{
+    /** @return list<array{ts:string, cpu_pct:?float, mem_used_pct:?float, temp_c:?float}> */
+    public function __invoke(int $deviceId, Carbon $from, Carbon $to): array
+    {
+        $maxPoints = max(1, (int) config('mymate.history.max_points', 240));
+        $span = max(1, $from->diffInSeconds($to));
+        $bucketSeconds = max(10, (int) ceil($span / $maxPoints));
+
+        $fromStr = $from->format('Y-m-d H:i:s');
+        $toStr = $to->format('Y-m-d H:i:s');
+
+        $rows = DB::select(
+            <<<'SQL'
+                SELECT date_bin(?::interval, ts, ?::timestamp) AS bucket,
+                       avg(cpu_pct)      AS cpu_pct,
+                       avg(mem_used_pct) AS mem_used_pct,
+                       avg(temp_c)       AS temp_c
+                FROM device_metric_samples
+                WHERE device_id = ? AND ts >= ?::timestamp AND ts < ?::timestamp
+                GROUP BY bucket
+                ORDER BY bucket
+            SQL,
+            ["{$bucketSeconds} seconds", $fromStr, $deviceId, $fromStr, $toStr],
+        );
+
+        return array_map(static fn ($r): array => [
+            'ts' => $r->bucket,
+            'cpu_pct' => self::num($r->cpu_pct, 2),
+            'mem_used_pct' => self::num($r->mem_used_pct, 2),
+            'temp_c' => self::num($r->temp_c, 1),
+        ], $rows);
+    }
+
+    private static function num(mixed $value, int $precision): ?float
+    {
+        return $value === null ? null : round((float) $value, $precision);
+    }
+}

--- a/app/Actions/History/ManageHistoryPartitions.php
+++ b/app/Actions/History/ManageHistoryPartitions.php
@@ -8,38 +8,45 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Roll the interface_samples daily partitions forward and drop expired ones
- *. Idempotent - safe to run repeatedly (loop cadence,
- * scheduler, or `mymate:loop --partitions`). Retention = drop partitions whose day
- * is older than `history.retention_days`.
+ * Roll the daily history partitions forward and drop expired ones for every
+ * RANGE-partitioned samples table (interface_samples + device_metric_samples).
+ * Idempotent - safe to run repeatedly (loop cadence, scheduler, or
+ * `mymate:loop --partitions`). Retention = drop partitions whose day is older than
+ * `history.retention_days`.
  */
 class ManageHistoryPartitions
 {
+    /** Parent tables that are daily-partitioned; each partition is "{table}_YYYYMMDD". */
+    private const TABLES = ['interface_samples', 'device_metric_samples'];
+
     /** @return array{created:int, dropped:int} */
     public function __invoke(): array
     {
         $ahead = max(0, (int) config('mymate.history.partitions_ahead', 3));
         // Retention is operator-editable - read the live Settings value.
         $retentionDays = max(1, app(Settings::class)->getInt('history.retention_days', 14));
+        $cutoff = now()->startOfDay()->subDays($retentionDays);
 
-        // Ensure [yesterday .. today+ahead] exist (yesterday covers writes that land
-        // just after a UTC-midnight rollover).
         $created = 0;
-        for ($i = -1; $i <= $ahead; $i++) {
-            if ($this->ensureDailyPartition(now()->startOfDay()->addDays($i))) {
-                $created++;
+        $dropped = 0;
+        foreach (self::TABLES as $table) {
+            // Ensure [yesterday .. today+ahead] exist (yesterday covers writes that land
+            // just after a UTC-midnight rollover).
+            for ($i = -1; $i <= $ahead; $i++) {
+                if ($this->ensureDailyPartition($table, now()->startOfDay()->addDays($i))) {
+                    $created++;
+                }
             }
+            $dropped += $this->dropPartitionsBefore($table, $cutoff);
         }
-
-        $dropped = $this->dropPartitionsBefore(now()->startOfDay()->subDays($retentionDays));
 
         return ['created' => $created, 'dropped' => $dropped];
     }
 
     /** Create the daily partition for $day if absent. Returns true if it created one. */
-    private function ensureDailyPartition(Carbon $day): bool
+    private function ensureDailyPartition(string $table, Carbon $day): bool
     {
-        $name = 'interface_samples_'.$day->format('Ymd');
+        $name = $table.'_'.$day->format('Ymd');
         if (Schema::hasTable($name)) {
             return false;
         }
@@ -48,20 +55,21 @@ class ManageHistoryPartitions
         $to = $day->copy()->addDay()->format('Y-m-d 00:00:00');
 
         DB::statement(
-            "CREATE TABLE IF NOT EXISTS \"{$name}\" PARTITION OF interface_samples FOR VALUES FROM ('{$from}') TO ('{$to}')"
+            "CREATE TABLE IF NOT EXISTS \"{$name}\" PARTITION OF {$table} FOR VALUES FROM ('{$from}') TO ('{$to}')"
         );
 
         return true;
     }
 
-    /** Drop every daily partition whose day is strictly before $cutoffDay. */
-    private function dropPartitionsBefore(Carbon $cutoffDay): int
+    /** Drop every daily partition of $table whose day is strictly before $cutoffDay. */
+    private function dropPartitionsBefore(string $table, Carbon $cutoffDay): int
     {
         $cutoff = (int) $cutoffDay->format('Ymd');
+        $prefixLen = strlen($table) + 1; // "{table}_"
         $dropped = 0;
 
-        foreach ($this->partitionNames() as $name) {
-            $datePart = substr($name, strlen('interface_samples_'));
+        foreach ($this->partitionNames($table) as $name) {
+            $datePart = substr($name, $prefixLen);
             if (strlen($datePart) !== 8 || ! ctype_digit($datePart)) {
                 continue; // not a YYYYMMDD daily partition - leave it alone
             }
@@ -74,16 +82,16 @@ class ManageHistoryPartitions
         return $dropped;
     }
 
-    /** @return list<string> child partition table names of interface_samples */
-    private function partitionNames(): array
+    /** @return list<string> child partition table names of $table */
+    private function partitionNames(string $table): array
     {
         $rows = DB::select(<<<'SQL'
             SELECT c.relname AS name
             FROM pg_inherits i
             JOIN pg_class c ON c.oid = i.inhrelid
             JOIN pg_class p ON p.oid = i.inhparent
-            WHERE p.relname = 'interface_samples'
-        SQL);
+            WHERE p.relname = ?
+        SQL, [$table]);
 
         return array_map(static fn ($r): string => $r->name, $rows);
     }

--- a/app/Actions/Polling/PollDeviceMetrics.php
+++ b/app/Actions/Polling/PollDeviceMetrics.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Actions\Polling;
+
+use App\Events\DeviceMetricsUpdated;
+use App\Models\Device;
+use App\Services\Polling\DeviceMetricsDriverFactory;
+use App\Support\EngineLog;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * A device-metrics tick for one shard of the fleet - the cpu/mem/temp counterpart to
+ * PollInterfaces. Polls each device (failures isolated), writes the latest values back
+ * onto the device row (the fast path the map tile reads), appends a history sample per
+ * device that produced any reading, and broadcasts the batch so tiles update live.
+ *
+ * Returns the number of devices that produced a reading.
+ */
+class PollDeviceMetrics
+{
+    public function __construct(private DeviceMetricsDriverFactory $drivers) {}
+
+    /** @param  list<int>  $deviceIds */
+    public function __invoke(array $deviceIds): int
+    {
+        if ($deviceIds === []) {
+            return 0;
+        }
+
+        $startedAt = microtime(true);
+        $now = now()->format('Y-m-d H:i:s');
+        $devices = Device::with('credential')->whereIn('id', $deviceIds)->get();
+
+        $frames = [];      // for the live broadcast
+        $sampleRows = [];  // for history
+        $failed = 0;
+
+        foreach ($devices as $device) {
+            try {
+                $metrics = $this->drivers->for($device)->sample($device);
+            } catch (\Throwable $e) {
+                // One black-holing/erroring device must not sink the batch. Driver
+                // exceptions carry host + transport error only, never credentials.
+                $failed++;
+                EngineLog::warning('metrics: device poll failed', [
+                    'device_id' => $device->id,
+                    'device' => $device->name,
+                    'ip' => $device->mgmt_ip,
+                    'method' => $device->poll_method->value,
+                    'exception' => $e::class,
+                    'error' => $e->getMessage(),
+                ]);
+
+                continue;
+            }
+
+            if ($metrics->isEmpty()) {
+                continue; // nothing readable - don't stamp metrics_at or write fake zeroes
+            }
+
+            // Latest values onto the device row (individually so one persist keeps the
+            // others - no bulk upsert here, the metrics fleet is device-count, not
+            // interface-count, so per-device updates are cheap enough).
+            $device->forceFill([
+                'cpu_pct' => $metrics->cpuPct,
+                'mem_used_pct' => $metrics->memUsedPct,
+                'temp_c' => $metrics->tempC,
+                'metrics_at' => now(),
+            ])->save();
+
+            $frames[] = [
+                'device_id' => $device->id,
+                'cpu_pct' => $metrics->cpuPct,
+                'mem_used_pct' => $metrics->memUsedPct,
+                'temp_c' => $metrics->tempC,
+            ];
+            $sampleRows[] = [
+                'device_id' => $device->id,
+                'ts' => $now,
+                'cpu_pct' => $metrics->cpuPct,
+                'mem_used_pct' => $metrics->memUsedPct,
+                'temp_c' => $metrics->tempC,
+            ];
+        }
+
+        $this->recordHistory($sampleRows);
+        $this->broadcast($frames);
+
+        EngineLog::debug('metrics: batch complete', [
+            'devices' => $devices->count(),
+            'polled' => count($frames),
+            'failed' => $failed,
+            'ms' => (int) round((microtime(true) - $startedAt) * 1000),
+        ]);
+
+        return count($frames);
+    }
+
+    /**
+     * Bulk-append history - one insert for the batch, best-effort (a DB hiccup or a
+     * momentarily-missing partition just loses that tick's history, never breaks a poll).
+     *
+     * @param  list<array<string, mixed>>  $rows
+     */
+    private function recordHistory(array $rows): void
+    {
+        if ($rows === [] || ! config('mymate.history.enabled', true)) {
+            return;
+        }
+
+        try {
+            DB::table('device_metric_samples')->insert($rows);
+        } catch (\Throwable $e) {
+            EngineLog::warning('metrics: history write failed', [
+                'rows' => count($rows),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /** @param  list<array{device_id:int, cpu_pct:?float, mem_used_pct:?float, temp_c:?float}>  $frames */
+    private function broadcast(array $frames): void
+    {
+        if ($frames === [] || ! config('mymate.device_metrics.broadcast', true)) {
+            return;
+        }
+
+        DeviceMetricsUpdated::dispatch($frames);
+    }
+}

--- a/app/Console/Commands/BackupConfigureCommand.php
+++ b/app/Console/Commands/BackupConfigureCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Support\BackupSettings;
+use Illuminate\Console\Command;
+
+/**
+ * Point My Mate at the Rusted backup engine without touching the Settings UI - used by
+ * the provisioning script (deploy/rusted/provision.sh) so a fresh install has working
+ * backups out of the box. Stores the URL + token in the encrypted settings row.
+ *
+ *   php artisan mymate:backup:configure --url http://127.0.0.1:8410 --token <token>
+ *   php artisan mymate:backup:configure --url http://127.0.0.1:8410 --from-rusted /etc/rusted/config.toml
+ */
+class BackupConfigureCommand extends Command
+{
+    protected $signature = 'mymate:backup:configure
+        {--url= : The Rusted API base URL (e.g. http://127.0.0.1:8410)}
+        {--token= : The Rusted API bearer token}
+        {--from-rusted= : Read the token from a rusted config.toml instead of --token}';
+
+    protected $description = 'Configure My Mate to talk to the Rusted backup engine';
+
+    public function handle(BackupSettings $settings): int
+    {
+        $url = (string) ($this->option('url') ?: config('mymate.backup.url'));
+        $token = (string) $this->option('token');
+
+        if ($token === '' && $this->option('from-rusted')) {
+            $token = $this->tokenFromConfig((string) $this->option('from-rusted'));
+        }
+
+        if ($url === '' || $token === '') {
+            $this->error('Need a --url and a --token (or --from-rusted <config.toml>).');
+
+            return self::FAILURE;
+        }
+
+        // Preserve any existing SSH-default fields; only (re)write url + token.
+        $current = $settings->publicView();
+        $settings->save([
+            'api_url' => $url,
+            'timeout' => $current['timeout'],
+            'ssh_username' => $current['ssh_username'],
+            'api_token' => $token,
+        ]);
+
+        $this->info("My Mate backups configured against {$url}.");
+
+        return self::SUCCESS;
+    }
+
+    /** Pull `api_token = "..."` out of a rusted config.toml. */
+    private function tokenFromConfig(string $path): string
+    {
+        if (! is_readable($path)) {
+            $this->error("Can't read rusted config at {$path}.");
+
+            return '';
+        }
+
+        foreach (file($path) ?: [] as $line) {
+            if (preg_match('/^\s*api_token\s*=\s*"([^"]+)"/', $line, $m) === 1) {
+                return $m[1];
+            }
+        }
+
+        $this->error("No api_token found in {$path}.");
+
+        return '';
+    }
+}

--- a/app/Console/Commands/LoopCommand.php
+++ b/app/Console/Commands/LoopCommand.php
@@ -59,7 +59,8 @@ class LoopCommand extends Command
         if ($this->option('once')) {
             PingSweepJob::dispatch();
             $n = $this->dispatchPoll();
-            $this->info("Dispatched one ping sweep + {$n} poll batch job(s).");
+            $m = $this->dispatchMetrics();
+            $this->info("Dispatched one ping sweep + {$n} poll + {$m} metrics batch job(s).");
 
             return self::SUCCESS;
         }
@@ -85,6 +86,7 @@ class LoopCommand extends Command
         ManageHistoryPartitionsJob::dispatch();
         $settings = app(Settings::class);
         $lastPoll = 0.0;
+        $lastMetrics = 0.0;
         $lastDiscover = microtime(true);
         $lastScanCheck = 0.0;
         $lastHistory = microtime(true);
@@ -93,6 +95,7 @@ class LoopCommand extends Command
             // Re-read cadences each cycle so a Settings change applies without a restart.
             $pingInterval = max(1, $settings->getInt('ping.interval', 5));
             $pollInterval = max(1, $settings->getInt('poll.interval', 12));
+            $metricsInterval = max(5, (int) config('mymate.device_metrics.interval', 30));
             $discoverInterval = max(60, $settings->getInt('poll.discover_interval', 600));
             $scanCheckInterval = max(5, $settings->getInt('discovery.check_interval', 30));
             $historyInterval = max(60, $settings->getInt('history.maintain_interval', 3600));
@@ -109,6 +112,11 @@ class LoopCommand extends Command
                 }
                 EvaluateAlertsJob::dispatch(); // evaluate alert policies on the poll cadence
                 $lastPoll = $now;
+            }
+            // Device resource metrics (cpu/mem/temp) on their own slower cadence.
+            if (config('mymate.device_metrics.enabled', true) && $now - $lastMetrics >= $metricsInterval) {
+                EngineLog::debug('loop: metrics dispatched', ['shards' => $this->dispatchMetrics()]);
+                $lastMetrics = $now;
             }
             if ($now - $lastDiscover >= $discoverInterval) {
                 EngineLog::debug('loop: discovery dispatched', ['devices' => $this->dispatchDiscovery()]);
@@ -135,6 +143,12 @@ class LoopCommand extends Command
     private function dispatchPoll(): int
     {
         return app(PollDispatcher::class)->dispatch();
+    }
+
+    /** Dispatch the sharded device-metrics (cpu/mem/temp) batch jobs. Returns shard count. */
+    private function dispatchMetrics(): int
+    {
+        return app(PollDispatcher::class)->dispatchMetrics();
     }
 
     /** Dispatch an interface-discovery job per pollable device. */

--- a/app/Console/Commands/MakeAdminCommand.php
+++ b/app/Console/Commands/MakeAdminCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+/**
+ * Grant (or revoke) admin rights on an existing operator by email:
+ * `php artisan mymate:user:admin someone@example.com`. Admin = operator-management
+ * rights; `is_admin` is not mass-assignable, so this is the supported way to flip it
+ * from the CLI. Use `--revoke` to demote back to a normal (view-only) operator.
+ */
+class MakeAdminCommand extends Command
+{
+    protected $signature = 'mymate:user:admin {email : The operator email} {--revoke : Remove admin rights instead of granting them}';
+
+    protected $description = 'Grant or revoke admin rights on an existing operator';
+
+    public function handle(): int
+    {
+        $email = $this->argument('email');
+        $user = User::where('email', $email)->first();
+
+        if ($user === null) {
+            $this->error("No operator found with email {$email}.");
+
+            return self::FAILURE;
+        }
+
+        $grant = ! $this->option('revoke');
+
+        if ($user->is_admin === $grant) {
+            $this->info("{$email} is already ".($grant ? 'an admin' : 'a normal operator').'. Nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        $user->is_admin = $grant; // explicit - is_admin is not fillable
+        $user->save();
+
+        $this->info($grant ? "{$email} is now an admin." : "{$email} is now a normal operator.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RunBackupsCommand.php
+++ b/app/Console/Commands/RunBackupsCommand.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Jobs\RunDeviceBackupJob;
 use App\Models\Device;
+use App\Support\BackupSchedule;
 use Illuminate\Console\Command;
 
 /**
@@ -16,12 +17,25 @@ use Illuminate\Console\Command;
  */
 class RunBackupsCommand extends Command
 {
-    protected $signature = 'mymate:backup:run {--all : back up every backup-enabled device} {--device= : back up a single device by id}';
+    protected $signature = 'mymate:backup:run
+        {--all : back up every backup-enabled device}
+        {--device= : back up a single device by id}
+        {--scheduled : run only if the configured schedule is due now (used by the scheduler)}';
 
     protected $description = 'Queue config backups (via the Rusted engine) for backup-enabled devices';
 
-    public function handle(): int
+    public function handle(BackupSchedule $schedule): int
     {
+        // Scheduler tick: only fire when the operator's configured cadence is due.
+        if ($this->option('scheduled')) {
+            if (! $schedule->due(now())) {
+                return self::SUCCESS;
+            }
+            $schedule->markRan(now());
+
+            return $this->runAll();
+        }
+
         $deviceId = $this->option('device');
 
         if ($deviceId !== null) {
@@ -43,6 +57,12 @@ class RunBackupsCommand extends Command
             return self::FAILURE;
         }
 
+        return $this->runAll();
+    }
+
+    /** Fan out a backup job for every backup-enabled device. */
+    private function runAll(): int
+    {
         $ids = Device::query()->where('backup_enabled', true)->pluck('id');
         foreach ($ids as $id) {
             RunDeviceBackupJob::dispatch($id);

--- a/app/Events/DeviceMetricsUpdated.php
+++ b/app/Events/DeviceMetricsUpdated.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Device resource metrics (cpu/mem/temp) for a poll tick, coalesced across devices -
+ * one event carries many devices' latest readings so the map tiles update live without
+ * a message per device. Mirrors InterfaceUtilUpdated but on the slower metrics cadence.
+ */
+class DeviceMetricsUpdated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @param  list<array{device_id:int, cpu_pct:?float, mem_used_pct:?float, temp_c:?float}>  $devices
+     */
+    public function __construct(public array $devices) {}
+
+    public function broadcastOn(): PrivateChannel
+    {
+        return new PrivateChannel('map');
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'DeviceMetricsUpdated';
+    }
+
+    /** @return array<string, mixed> */
+    public function broadcastWith(): array
+    {
+        return [
+            'devices' => $this->devices,
+            'device_count' => count($this->devices),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/BackupSettingController.php
+++ b/app/Http/Controllers/Api/BackupSettingController.php
@@ -27,6 +27,40 @@ class BackupSettingController extends Controller
         return response()->json(['data' => $settings->publicView()]);
     }
 
+    /** Queue a backup now for every backup-enabled device. */
+    public function runAll(BackupSettings $settings): JsonResponse
+    {
+        if (! $settings->configured()) {
+            return response()->json(['message' => 'The backup engine (Rusted) is not configured yet.'], 422);
+        }
+        $ids = \App\Models\Device::where('backup_enabled', true)->pluck('id');
+        foreach ($ids as $id) {
+            \App\Jobs\RunDeviceBackupJob::dispatch($id);
+        }
+
+        return response()->json(['queued' => $ids->count()], 202);
+    }
+
+    /** The automatic-backup schedule (cadence + on/off). */
+    public function schedule(\App\Support\BackupSchedule $schedule): JsonResponse
+    {
+        return response()->json(['data' => $schedule->get()]);
+    }
+
+    /** Save the automatic-backup schedule. */
+    public function updateSchedule(\Illuminate\Http\Request $request, \App\Support\BackupSchedule $schedule): JsonResponse
+    {
+        $validated = $request->validate([
+            'enabled' => ['required', 'boolean'],
+            'frequency' => ['required', \Illuminate\Validation\Rule::in(\App\Support\BackupSchedule::FREQUENCIES)],
+            'hour' => ['required', 'integer', 'min:0', 'max:23'],
+            'weekday' => ['required', 'integer', 'min:0', 'max:6'],
+        ]);
+        $schedule->save($validated);
+
+        return response()->json(['data' => $schedule->get()]);
+    }
+
     /**
      * Reachability check - does Rusted answer on the configured URL/token? Returns only a
      * boolean (like {@see MailSettingController::test()}, no raw error is echoed so this

--- a/app/Http/Controllers/Api/DeviceBackupController.php
+++ b/app/Http/Controllers/Api/DeviceBackupController.php
@@ -75,6 +75,36 @@ class DeviceBackupController extends Controller
     }
 
     /**
+     * Bootstrap key-based SSH over the RouterOS API (MikroTik can't export over the API):
+     * Rusted installs a generated key and returns it; we store it as the device's SSH
+     * credential and switch it to SSH backups. Reports whether SSH had to be enabled.
+     */
+    public function provisionKey(Device $device, \App\Actions\Backup\ProvisionSshKey $provision, BackupSettings $settings): JsonResponse
+    {
+        if (! $settings->configured()) {
+            return response()->json(['message' => 'The backup engine (Rusted) is not configured yet - set it up in Settings.'], 422);
+        }
+
+        try {
+            $result = $provision($device);
+        } catch (\Throwable $e) {
+            EngineLog::warning('backup: ssh-key provisioning failed', ['device_id' => $device->id, 'error' => $e->getMessage()]);
+
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return response()->json([
+            'message' => $result['ssh_enabled_by']
+                ? "SSH key installed and the SSH service was enabled (port {$result['ssh_port']})."
+                : "SSH key installed (SSH already on, port {$result['ssh_port']}).",
+            'device' => new DeviceResource($device->fresh()),
+            'ssh_port' => $result['ssh_port'],
+            'ssh_enabled' => $result['ssh_enabled'],
+            'ssh_enabled_by' => $result['ssh_enabled_by'],
+        ]);
+    }
+
+    /**
      * Backup history for a device, proxied live from Rusted (newest first). Returns [] when
      * the engine is unconfigured/unreachable rather than erroring - the inspector just shows
      * "no history yet".

--- a/app/Http/Controllers/Api/DeviceBackupController.php
+++ b/app/Http/Controllers/Api/DeviceBackupController.php
@@ -140,4 +140,50 @@ class DeviceBackupController extends Controller
 
         return response()->json(['data' => ['config' => $config]]);
     }
+
+    /** Config version history (git log) for a device, newest first. */
+    public function versions(Device $device, RustedClient $client, BackupSettings $settings): JsonResponse
+    {
+        if (! $settings->configured()) {
+            return response()->json(['data' => []]);
+        }
+
+        try {
+            $versions = $client->versions(RegisterBackupDevice::rustedName($device));
+        } catch (\Throwable $e) {
+            EngineLog::warning('backup: versions fetch failed', ['device_id' => $device->id, 'error' => $e->getMessage()]);
+            $versions = [];
+        }
+
+        return response()->json(['data' => $versions]);
+    }
+
+    /** The stored config at a specific commit (?commit=), for viewing an old version. */
+    public function configAt(\Illuminate\Http\Request $request, Device $device, RustedClient $client): JsonResponse
+    {
+        $commit = (string) $request->query('commit', '');
+        $config = null;
+        try {
+            $config = $commit !== '' ? $client->configAt(RegisterBackupDevice::rustedName($device), $commit) : null;
+        } catch (\Throwable $e) {
+            EngineLog::warning('backup: config-at-commit failed', ['device_id' => $device->id, 'error' => $e->getMessage()]);
+        }
+
+        return response()->json(['data' => ['config' => $config]]);
+    }
+
+    /** Unified diff of a device's config - ?from=<hash> alone shows what that backup changed. */
+    public function diff(\Illuminate\Http\Request $request, Device $device, RustedClient $client): JsonResponse
+    {
+        $from = (string) $request->query('from', '');
+        $to = (string) $request->query('to', '');
+        $diff = null;
+        try {
+            $diff = $from !== '' ? $client->diff(RegisterBackupDevice::rustedName($device), $from, $to) : null;
+        } catch (\Throwable $e) {
+            EngineLog::warning('backup: diff failed', ['device_id' => $device->id, 'error' => $e->getMessage()]);
+        }
+
+        return response()->json(['data' => ['diff' => $diff]]);
+    }
 }

--- a/app/Http/Controllers/Api/DeviceController.php
+++ b/app/Http/Controllers/Api/DeviceController.php
@@ -66,9 +66,10 @@ class DeviceController extends Controller
      */
     public function upgradePreflight(UpgradeDevicesRequest $request, UpgradePreflight $preflight): JsonResponse
     {
-        $ids = array_map('intval', $request->validated()['device_ids']);
+        $data = $request->validated();
+        $ids = array_map('intval', $data['device_ids']);
 
-        return response()->json($preflight($ids));
+        return response()->json($preflight($ids, (bool) ($data['preserve_order'] ?? false)));
     }
 
     /**
@@ -89,7 +90,7 @@ class DeviceController extends Controller
         ]);
 
         if ($data['ordered'] ?? false) {
-            BulkUpgradeJob::dispatch($ids);
+            BulkUpgradeJob::dispatch($ids, (bool) ($data['explicit_order'] ?? false));
         } else {
             foreach ($ids as $id) {
                 UpgradeDeviceJob::dispatch($id);

--- a/app/Http/Controllers/Api/InterfaceSampleController.php
+++ b/app/Http/Controllers/Api/InterfaceSampleController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\History\GetDeviceMetricSamples;
 use App\Actions\History\GetDeviceSamples;
 use App\Actions\History\GetInterfaceSamples;
 use App\Http\Controllers\Controller;
@@ -31,6 +32,17 @@ class InterfaceSampleController extends Controller
      * bucket (util averaged). Backs the inspector's device-level chart.
      */
     public function device(Request $request, Device $device, GetDeviceSamples $get): JsonResponse
+    {
+        [$from, $to] = $this->window($request);
+
+        return response()->json(['data' => $get($device->id, $from, $to)]);
+    }
+
+    /**
+     * GET /api/devices/{device}/metric-samples?from&to
+     * Bucketed cpu/mem/temp history for the device - backs the inspector's resource chart.
+     */
+    public function metrics(Request $request, Device $device, GetDeviceMetricSamples $get): JsonResponse
     {
         [$from, $to] = $this->window($request);
 

--- a/app/Http/Requests/Credential/StoreCredentialRequest.php
+++ b/app/Http/Requests/Credential/StoreCredentialRequest.php
@@ -17,10 +17,11 @@ class StoreCredentialRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'type' => ['required', Rule::in(['snmp', 'routeros'])],
+            'type' => ['required', Rule::in(['snmp', 'routeros', 'ssh'])],
             'snmp_community' => ['nullable', 'string', 'required_if:type,snmp'],
-            'username' => ['nullable', 'string', 'required_if:type,routeros'],
-            'password' => ['nullable', 'string', 'required_if:type,routeros'],
+            // RouterOS + SSH creds are username/password logins.
+            'username' => ['nullable', 'string', Rule::requiredIf(fn () => in_array($this->input('type'), ['routeros', 'ssh'], true))],
+            'password' => ['nullable', 'string', Rule::requiredIf(fn () => in_array($this->input('type'), ['routeros', 'ssh'], true))],
             'api_port' => ['nullable', 'integer', 'min:1', 'max:65535'],
         ];
     }

--- a/app/Http/Requests/Credential/UpdateCredentialRequest.php
+++ b/app/Http/Requests/Credential/UpdateCredentialRequest.php
@@ -21,7 +21,7 @@ class UpdateCredentialRequest extends FormRequest
     {
         return [
             'name' => ['sometimes', 'required', 'string', 'max:255'],
-            'type' => ['sometimes', 'required', Rule::in(['snmp', 'routeros'])],
+            'type' => ['sometimes', 'required', Rule::in(['snmp', 'routeros', 'ssh'])],
             'snmp_community' => ['nullable', 'string'],
             'username' => ['nullable', 'string'],
             'password' => ['nullable', 'string'],

--- a/app/Http/Requests/Device/StoreDeviceRequest.php
+++ b/app/Http/Requests/Device/StoreDeviceRequest.php
@@ -22,6 +22,7 @@ class StoreDeviceRequest extends FormRequest
             'mgmt_ip' => ['required', 'string', 'max:45', 'ip', new ManageableIp],
             'poll_method' => ['required', Rule::enum(PollMethod::class)],
             'credential_id' => ['nullable', 'integer', 'exists:credentials,id'],
+            'ssh_credential_id' => ['nullable', 'integer', 'exists:credentials,id'],
             'agent_id' => ['nullable', 'integer', 'exists:agents,id'],
             'map_x' => ['nullable', 'numeric'],
             'map_y' => ['nullable', 'numeric'],

--- a/app/Http/Requests/Device/UpdateDeviceRequest.php
+++ b/app/Http/Requests/Device/UpdateDeviceRequest.php
@@ -21,6 +21,8 @@ class UpdateDeviceRequest extends FormRequest
             'name' => ['sometimes', 'required', 'string', 'max:255'],
             'mgmt_ip' => ['sometimes', 'required', 'string', 'max:45', 'ip', new ManageableIp],
             'poll_method' => ['sometimes', 'required', Rule::enum(PollMethod::class)],
+            // Enable/disable monitoring - false pauses throughput + metrics polling.
+            'monitored' => ['sometimes', 'boolean'],
             'credential_id' => ['nullable', 'integer', 'exists:credentials,id'],
             'agent_id' => ['nullable', 'integer', 'exists:agents,id'],
             'map_x' => ['sometimes', 'numeric'],

--- a/app/Http/Requests/Device/UpdateDeviceRequest.php
+++ b/app/Http/Requests/Device/UpdateDeviceRequest.php
@@ -24,6 +24,7 @@ class UpdateDeviceRequest extends FormRequest
             // Enable/disable monitoring - false pauses throughput + metrics polling.
             'monitored' => ['sometimes', 'boolean'],
             'credential_id' => ['nullable', 'integer', 'exists:credentials,id'],
+            'ssh_credential_id' => ['nullable', 'integer', 'exists:credentials,id'],
             'agent_id' => ['nullable', 'integer', 'exists:agents,id'],
             'map_x' => ['sometimes', 'numeric'],
             'map_y' => ['sometimes', 'numeric'],

--- a/app/Http/Requests/Device/UpgradeDevicesRequest.php
+++ b/app/Http/Requests/Device/UpgradeDevicesRequest.php
@@ -23,6 +23,11 @@ class UpgradeDevicesRequest extends FormRequest
             // Ordered = upgrade downstream-first, waiting for each device to recover
             // before its parent (one BulkUpgradeJob). Unordered = one job per device.
             'ordered' => ['sometimes', 'boolean'],
+            // Keep device_ids in the given order instead of re-sorting furthest-first
+            // (the rolling-upgrades page after a manual re-order). Only meaningful with ordered.
+            'explicit_order' => ['sometimes', 'boolean'],
+            // Also accepted by the preflight endpoint to preview in the given order.
+            'preserve_order' => ['sometimes', 'boolean'],
         ];
     }
 }

--- a/app/Http/Requests/Link/StoreLinkRequest.php
+++ b/app/Http/Requests/Link/StoreLinkRequest.php
@@ -19,13 +19,14 @@ class StoreLinkRequest extends FormRequest
         return [
             'a_device_id' => ['required', 'integer', 'exists:devices,id'],
             'b_device_id' => ['required', 'integer', 'exists:devices,id'],
-            // Each interface must belong to its device end (also enforced by a DB trigger).
+            // Nullable: a ping-only device (no interfaces) links from the other end only.
+            // When present, each interface must belong to its device end (also a DB trigger).
             'a_interface_id' => [
-                'required', 'integer', 'different:b_interface_id',
+                'nullable', 'integer',
                 Rule::exists('interfaces', 'id')->where('device_id', $this->input('a_device_id')),
             ],
             'b_interface_id' => [
-                'required', 'integer',
+                'nullable', 'integer',
                 Rule::exists('interfaces', 'id')->where('device_id', $this->input('b_device_id')),
             ],
             // Per-direction bandwidth override. Nullable = "use the
@@ -35,30 +36,48 @@ class StoreLinkRequest extends FormRequest
         ];
     }
 
-    /** Reject a duplicate link between the same two interfaces, in either direction. */
+    /**
+     * Reject an interface linked to itself, and a duplicate link between the same two
+     * ends (device+interface, either direction). Null-aware so ping-only ends compare
+     * correctly (SQL `= NULL` never matches, so a null end needs whereNull).
+     */
     public function withValidator(Validator $validator): void
     {
         $validator->after(function (Validator $validator): void {
+            $aDev = $this->input('a_device_id');
+            $bDev = $this->input('b_device_id');
             $a = $this->input('a_interface_id');
             $b = $this->input('b_interface_id');
-            if ($a === null || $b === null) {
+
+            // A real interface can't be both ends of one link.
+            if ($a !== null && $a === $b) {
+                $validator->errors()->add('a_interface_id', "An interface can't link to itself.");
+
                 return;
             }
 
             $duplicate = Link::query()
                 ->when($this->ignoredLinkId(), fn ($q, $id) => $q->whereKeyNot($id))
-                ->where(function ($q) use ($a, $b): void {
-                    // Match the pair in either direction - grouped so the id exclusion
-                    // above applies to BOTH branches (not just the first).
-                    $q->where(fn ($qq) => $qq->where('a_interface_id', $a)->where('b_interface_id', $b))
-                        ->orWhere(fn ($qq) => $qq->where('a_interface_id', $b)->where('b_interface_id', $a));
+                ->where(function ($q) use ($aDev, $a, $bDev, $b): void {
+                    // Same pair in either direction. Grouped so the id exclusion above
+                    // applies to BOTH branches.
+                    $q->where(fn ($qq) => $this->matchEnds($qq, $aDev, $a, $bDev, $b))
+                        ->orWhere(fn ($qq) => $this->matchEnds($qq, $bDev, $b, $aDev, $a));
                 })
                 ->exists();
 
             if ($duplicate) {
-                $validator->errors()->add('a_interface_id', 'These interfaces are already linked.');
+                $validator->errors()->add('a_interface_id', 'These devices are already linked on those interfaces.');
             }
         });
+    }
+
+    /** Constrain a query to a link whose A end is ($aDev,$aIf) and B end is ($bDev,$bIf), null-safe. */
+    private function matchEnds($query, ?int $aDev, ?int $aIf, ?int $bDev, ?int $bIf): void
+    {
+        $query->where('a_device_id', $aDev)->where('b_device_id', $bDev);
+        $aIf === null ? $query->whereNull('a_interface_id') : $query->where('a_interface_id', $aIf);
+        $bIf === null ? $query->whereNull('b_interface_id') : $query->where('b_interface_id', $bIf);
     }
 
     /**

--- a/app/Http/Resources/CredentialResource.php
+++ b/app/Http/Resources/CredentialResource.php
@@ -18,7 +18,9 @@ class CredentialResource extends JsonResource
             'name' => $this->name,
             'type' => $this->type,
             'api_port' => $this->api_port,
-            'has_secret' => $this->type === 'snmp' ? filled($this->snmp_community) : filled($this->password),
+            'has_secret' => $this->type === 'snmp'
+                ? filled($this->snmp_community)
+                : (filled($this->password) || filled($this->private_key)),
             'device_count' => $this->devices_count ?? 0,
         ];
     }

--- a/app/Http/Resources/DeviceResource.php
+++ b/app/Http/Resources/DeviceResource.php
@@ -14,6 +14,7 @@ class DeviceResource extends JsonResource
             'name' => $this->name,
             'mgmt_ip' => $this->mgmt_ip,
             'poll_method' => $this->poll_method->value,
+            'monitored' => (bool) $this->monitored,
             'status' => $this->status->value,
             'last_change' => $this->last_change,
             'map_x' => $this->map_x,

--- a/app/Http/Resources/DeviceResource.php
+++ b/app/Http/Resources/DeviceResource.php
@@ -40,6 +40,11 @@ class DeviceResource extends JsonResource
             // Interface-discovery visibility.
             'discovery_error' => $this->discovery_error,
             'discovered_at' => $this->discovered_at,
+            // Resource metrics (latest poll) - the map tile can show any of these.
+            'cpu_pct' => $this->cpu_pct,
+            'mem_used_pct' => $this->mem_used_pct,
+            'temp_c' => $this->temp_c,
+            'metrics_at' => $this->metrics_at,
             // Config-backup mirror - last run cached from Rusted.
             'backup_enabled' => (bool) $this->backup_enabled,
             'backup_driver' => $this->backup_driver,

--- a/app/Http/Resources/DeviceResource.php
+++ b/app/Http/Resources/DeviceResource.php
@@ -20,6 +20,7 @@ class DeviceResource extends JsonResource
             'map_x' => $this->map_x,
             'map_y' => $this->map_y,
             'credential_id' => $this->credential_id,
+            'ssh_credential_id' => $this->ssh_credential_id,
             'agent_id' => $this->agent_id,
             // NOC-console metadata.
             'device_type' => $this->device_type?->value ?? 'unknown',

--- a/app/Jobs/BulkUpgradeJob.php
+++ b/app/Jobs/BulkUpgradeJob.php
@@ -23,14 +23,14 @@ class BulkUpgradeJob implements ShouldQueue
     public int $tries = 1;
 
     /** @param list<int> $deviceIds */
-    public function __construct(public array $deviceIds)
+    public function __construct(public array $deviceIds, public bool $preserveOrder = false)
     {
         $this->onQueue('upgrade');
     }
 
     public function handle(RunBulkUpgrade $run): void
     {
-        $run($this->deviceIds);
+        $run($this->deviceIds, $this->preserveOrder);
     }
 
     /** @return array<int, object> */

--- a/app/Jobs/PollDeviceMetricsBatchJob.php
+++ b/app/Jobs/PollDeviceMetricsBatchJob.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Actions\Polling\PollDeviceMetrics;
+use App\Support\EngineLog;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Throwable;
+
+/**
+ * Queue envelope: one device-metrics tick for one shard of the fleet - the cpu/mem/temp
+ * sibling of PollInterfacesBatchJob. Per-shard overlap lock gives backpressure (a slow
+ * shard skips its next tick) and cross-daemon safety.
+ */
+class PollDeviceMetricsBatchJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    /** @param  list<int>  $deviceIds */
+    public function __construct(public int $shard, public array $deviceIds)
+    {
+        $this->onQueue('poll');
+    }
+
+    public function handle(PollDeviceMetrics $poll): void
+    {
+        $poll($this->deviceIds);
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [(new WithoutOverlapping("metrics-shard-{$this->shard}"))->dontRelease()->expireAfter(60)];
+    }
+
+    public function failed(Throwable $e): void
+    {
+        EngineLog::error('metrics: batch job failed', [
+            'shard' => $this->shard,
+            'devices' => count($this->deviceIds),
+            'exception' => $e::class,
+            'error' => $e->getMessage(),
+        ]);
+    }
+}

--- a/app/Models/Credential.php
+++ b/app/Models/Credential.php
@@ -13,18 +13,19 @@ class Credential extends Model
     use HasFactory;
 
     protected $fillable = [
-        'name', 'type', 'snmp_community', 'username', 'password', 'api_port',
+        'name', 'type', 'snmp_community', 'username', 'password', 'private_key', 'api_port',
     ];
 
     protected $casts = [
         'snmp_community' => 'encrypted',
         'username' => 'encrypted',
         'password' => 'encrypted',
+        'private_key' => 'encrypted',
         'api_port' => 'integer',
     ];
 
     // Never expose secrets when serialised to JSON (e.g. via API resources).
-    protected $hidden = ['snmp_community', 'username', 'password'];
+    protected $hidden = ['snmp_community', 'username', 'password', 'private_key'];
 
     public function devices(): HasMany
     {

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -19,7 +19,7 @@ class Device extends Model
     use HasFactory;
 
     protected $fillable = [
-        'name', 'mgmt_ip', 'poll_method', 'credential_id', 'agent_id',
+        'name', 'mgmt_ip', 'poll_method', 'credential_id', 'ssh_credential_id', 'agent_id',
         'status', 'monitored', 'last_change', 'map_x', 'map_y',
         'device_type', 'parent_device_id', 'vendor', 'model', 'uptime_seconds', 'uptime_at',
         'os_version', 'latest_version', 'upgrade_status', 'upgrade_message', 'upgrade_at',
@@ -64,6 +64,12 @@ class Device extends Model
     public function credential(): BelongsTo
     {
         return $this->belongsTo(Credential::class);
+    }
+
+    /** Dedicated SSH credential for config backups (separate from the poll credential). */
+    public function sshCredential(): BelongsTo
+    {
+        return $this->belongsTo(Credential::class, 'ssh_credential_id');
     }
 
     /** The remote agent that polls this device, or null when polled centrally. */

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -24,6 +24,7 @@ class Device extends Model
         'device_type', 'parent_device_id', 'vendor', 'model', 'uptime_seconds', 'uptime_at',
         'os_version', 'latest_version', 'upgrade_status', 'upgrade_message', 'upgrade_at',
         'discovery_error', 'discovered_at',
+        'cpu_pct', 'mem_used_pct', 'temp_c', 'metrics_at',
         'backup_enabled', 'backup_driver', 'backup_status', 'backup_message', 'backup_at', 'backup_commit',
     ];
 
@@ -38,6 +39,10 @@ class Device extends Model
         'map_y' => 'float',
         'uptime_seconds' => 'integer',
         'uptime_at' => 'datetime',
+        'cpu_pct' => 'float',
+        'mem_used_pct' => 'float',
+        'temp_c' => 'float',
+        'metrics_at' => 'datetime',
         'upgrade_at' => 'datetime',
         'discovered_at' => 'datetime',
         'backup_enabled' => 'boolean',

--- a/app/Services/Backup/RustedClient.php
+++ b/app/Services/Backup/RustedClient.php
@@ -59,6 +59,25 @@ class RustedClient
         return $this->client()->get('/api/drivers')->throw()->json() ?? [];
     }
 
+    /**
+     * Install a generated SSH key on a RouterOS device over its API and get the private key
+     * back, so the device can be backed up over SSH (RouterOS won't export over the API).
+     *
+     * @return array{user:string, private_key:string, ssh_port:int, ssh_enabled:bool, ssh_enabled_by:bool}
+     */
+    public function provisionMikrotikSshKey(string $host, int $port, string $username, string $password): array
+    {
+        return $this->client()
+            ->post('/api/provision/mikrotik-ssh-key', [
+                'host' => $host,
+                'port' => $port,
+                'username' => $username,
+                'password' => $password,
+            ])
+            ->throw()
+            ->json();
+    }
+
     /** Upsert a Rusted credential (name-keyed). @param array<string,mixed> $payload */
     public function putCredential(array $payload): void
     {

--- a/app/Services/Backup/RustedClient.php
+++ b/app/Services/Backup/RustedClient.php
@@ -128,6 +128,43 @@ class RustedClient
     }
 
     /**
+     * Config version history (git log of the device's config file), newest first.
+     *
+     * @return array<int, array{commit:string, date:string, subject:string}>
+     */
+    public function versions(string $name): array
+    {
+        $res = $this->client()->get('/api/devices/'.rawurlencode($name).'/versions');
+        if ($res->status() === 404) {
+            return [];
+        }
+
+        return $res->throw()->json() ?? [];
+    }
+
+    /** Config text at a specific commit, or null if not found (404). */
+    public function configAt(string $name, string $commit): ?string
+    {
+        $res = $this->client()->get('/api/devices/'.rawurlencode($name).'/config', ['commit' => $commit]);
+        if ($res->status() === 404) {
+            return null;
+        }
+
+        return $res->throw()->body();
+    }
+
+    /** Unified diff of a device's config. `from` alone shows what that backup changed. */
+    public function diff(string $name, string $from, string $to = ''): ?string
+    {
+        $res = $this->client()->get('/api/devices/'.rawurlencode($name).'/diff', array_filter(['from' => $from, 'to' => $to]));
+        if ($res->status() === 404) {
+            return null;
+        }
+
+        return $res->throw()->body();
+    }
+
+    /**
      * Trigger a backup now and return Rusted's result ({status, message, commit, bytes, ...}).
      * Synchronous - Rusted SSHes to the device and captures the config before responding,
      * which is why callers run this on the isolated `backup` queue with a long timeout.

--- a/app/Services/Polling/DeviceMetricProfiles.php
+++ b/app/Services/Polling/DeviceMetricProfiles.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services\Polling;
+
+use App\Models\Device;
+
+/**
+ * Resolves the SNMP OID profile to read a device's cpu/mem/temp with. Matched by a
+ * case-insensitive substring of the device's detected vendor (e.g. "MikroTik", "Cisco")
+ * against the profile keys in config('mymate.device_metrics.profiles'); falls back to
+ * the 'default' host-resources-MIB profile when nothing matches.
+ */
+class DeviceMetricProfiles
+{
+    /** @return array<string, mixed> */
+    public function for(Device $device): array
+    {
+        /** @var array<string, array<string, mixed>> $profiles */
+        $profiles = config('mymate.device_metrics.profiles', []);
+        $vendor = strtolower(trim((string) $device->vendor));
+
+        if ($vendor !== '') {
+            foreach ($profiles as $key => $profile) {
+                if ($key !== 'default' && str_contains($vendor, strtolower($key))) {
+                    return $profile;
+                }
+            }
+        }
+
+        return $profiles['default'] ?? [];
+    }
+}

--- a/app/Services/Polling/DeviceMetrics.php
+++ b/app/Services/Polling/DeviceMetrics.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Polling;
+
+/**
+ * One device's resource reading. Every field is nullable - a device may expose some
+ * metrics and not others (a switch with no temp sensor, an agent that answers cpu but
+ * not memory), and a null just means "not available", not zero.
+ */
+class DeviceMetrics
+{
+    public function __construct(
+        public readonly ?float $cpuPct = null,
+        public readonly ?float $memUsedPct = null,
+        public readonly ?float $tempC = null,
+    ) {}
+
+    /** True when nothing was read - the poller skips these so history has no fake zeroes. */
+    public function isEmpty(): bool
+    {
+        return $this->cpuPct === null && $this->memUsedPct === null && $this->tempC === null;
+    }
+
+    /** Clamp a percentage into 0-100, or null. */
+    public static function clampPct(?float $v): ?float
+    {
+        if ($v === null) {
+            return null;
+        }
+
+        return max(0.0, min(100.0, $v));
+    }
+}

--- a/app/Services/Polling/DeviceMetricsDriver.php
+++ b/app/Services/Polling/DeviceMetricsDriver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services\Polling;
+
+use App\Models\Device;
+
+/**
+ * Reads a device's resource metrics (cpu/mem/temp) for one tick. Implementations
+ * fail fast on an unreachable/filtered host (the orchestrator isolates per device).
+ */
+interface DeviceMetricsDriver
+{
+    public function sample(Device $device): DeviceMetrics;
+}

--- a/app/Services/Polling/DeviceMetricsDriverFactory.php
+++ b/app/Services/Polling/DeviceMetricsDriverFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services\Polling;
+
+use App\Enums\PollMethod;
+use App\Models\Device;
+
+/**
+ * Picks the metrics driver for a device by its poll_method - mirrors
+ * ThroughputDriverFactory. Ping-only devices have no metrics source.
+ */
+class DeviceMetricsDriverFactory
+{
+    public function __construct(
+        private SnmpDeviceMetricsDriver $snmp,
+        private RouterOsDeviceMetricsDriver $routerOs,
+    ) {}
+
+    public function for(Device $device): DeviceMetricsDriver
+    {
+        return match ($device->poll_method) {
+            PollMethod::Snmp => $this->snmp,
+            PollMethod::RouterOs => $this->routerOs,
+            PollMethod::None => throw new \InvalidArgumentException(
+                "Device {$device->id} is ping-only (poll_method=none) and has no metrics driver.",
+            ),
+        };
+    }
+}

--- a/app/Services/Polling/PollDispatcher.php
+++ b/app/Services/Polling/PollDispatcher.php
@@ -3,6 +3,7 @@
 namespace App\Services\Polling;
 
 use App\Enums\PollMethod;
+use App\Jobs\PollDeviceMetricsBatchJob;
 use App\Jobs\PollInterfacesBatchJob;
 use App\Models\Device;
 
@@ -43,6 +44,38 @@ class PollDispatcher
 
         foreach ($byShard as $shard => $shardIds) {
             PollInterfacesBatchJob::dispatch($shard, $shardIds);
+        }
+
+        return count($byShard);
+    }
+
+    /**
+     * Shard the same pollable fleet into device-metrics (cpu/mem/temp) batch jobs. Same
+     * shard key as throughput so a device's metrics and throughput land on matching shard
+     * numbers; dispatched on the (slower) device-metrics cadence from the loop.
+     *
+     * @return int number of batch jobs dispatched (non-empty shards)
+     */
+    public function dispatchMetrics(): int
+    {
+        $shards = max(1, (int) config('mymate.poll.shards', 16));
+
+        $ids = Device::where('monitored', true)
+            ->whereNull('agent_id')
+            ->whereIn('poll_method', PollMethod::throughputMethods())
+            ->pluck('id');
+        if ($ids->isEmpty()) {
+            return 0;
+        }
+
+        /** @var array<int, list<int>> $byShard */
+        $byShard = [];
+        foreach ($ids as $id) {
+            $byShard[crc32((string) $id) % $shards][] = (int) $id;
+        }
+
+        foreach ($byShard as $shard => $shardIds) {
+            PollDeviceMetricsBatchJob::dispatch($shard, $shardIds);
         }
 
         return count($byShard);

--- a/app/Services/Polling/RouterOsDeviceMetricsDriver.php
+++ b/app/Services/Polling/RouterOsDeviceMetricsDriver.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Services\Polling;
+
+use App\Models\Device;
+use App\Services\RouterOs\RouterOsClient;
+use App\Services\RouterOs\RouterOsTarget;
+
+/**
+ * CPU / memory / temperature over the RouterOS binary API (MikroTik). Reads
+ * `/system/resource` (cpu-load + free/total memory) and best-effort `/system/health`
+ * (board/CPU temperature - shape differs across RouterOS 6 and 7, both handled).
+ */
+class RouterOsDeviceMetricsDriver implements DeviceMetricsDriver
+{
+    public function __construct(private RouterOsClient $client) {}
+
+    public function sample(Device $device): DeviceMetrics
+    {
+        $conn = $this->client->open(RouterOsTarget::fromDevice($device));
+
+        try {
+            $res = $conn->query('/system/resource')[0] ?? [];
+
+            $cpu = isset($res['cpu-load']) && is_numeric($res['cpu-load']) ? (float) $res['cpu-load'] : null;
+
+            $mem = null;
+            $total = (float) ($res['total-memory'] ?? 0);
+            $free = (float) ($res['free-memory'] ?? 0);
+            if ($total > 0) {
+                $mem = (($total - $free) / $total) * 100;
+            }
+
+            return new DeviceMetrics(
+                cpuPct: DeviceMetrics::clampPct($cpu),
+                memUsedPct: DeviceMetrics::clampPct($mem),
+                tempC: $this->temperature($conn),
+            );
+        } finally {
+            $conn->close();
+        }
+    }
+
+    /** Best-effort - /system/health is unavailable on some boards; never let it fail the read. */
+    private function temperature(\App\Services\RouterOs\RouterOsConnection $conn): ?float
+    {
+        try {
+            $rows = $conn->query('/system/health');
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $temps = [];
+        foreach ($rows as $row) {
+            // RouterOS 6: a single row with a `temperature` (and maybe `cpu-temperature`) key.
+            foreach (['cpu-temperature', 'temperature', 'board-temperature'] as $key) {
+                if (isset($row[$key]) && is_numeric($row[$key])) {
+                    $temps[] = (float) $row[$key];
+                }
+            }
+            // RouterOS 7: one row per sensor, {name: "...temperature", value: "42"}.
+            $name = strtolower((string) ($row['name'] ?? ''));
+            if (str_contains($name, 'temperature') && isset($row['value']) && is_numeric($row['value'])) {
+                $temps[] = (float) $row['value'];
+            }
+        }
+
+        $temps = array_filter($temps, static fn (float $v): bool => $v > 0);
+
+        return $temps === [] ? null : max($temps);
+    }
+}

--- a/app/Services/Polling/SnmpDeviceMetricsDriver.php
+++ b/app/Services/Polling/SnmpDeviceMetricsDriver.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Services\Polling;
+
+use App\Models\Device;
+use App\Services\Snmp\SnmpClient;
+use App\Services\Snmp\SnmpClientException;
+
+/**
+ * CPU / memory / temperature over SNMP, driven by a per-vendor OID profile
+ * (see DeviceMetricProfiles + config('mymate.device_metrics.profiles')). Each metric is
+ * best-effort and independent: an OID the agent doesn't implement just leaves that metric
+ * null rather than failing the whole read. A transport failure (timeout/filtered) throws
+ * so the orchestrator can isolate the device.
+ */
+class SnmpDeviceMetricsDriver implements DeviceMetricsDriver
+{
+    public function __construct(
+        private SnmpClient $snmp,
+        private DeviceMetricProfiles $profiles,
+    ) {}
+
+    public function sample(Device $device): DeviceMetrics
+    {
+        [$host, $community] = $this->target($device);
+        $profile = $this->profiles->for($device);
+
+        return new DeviceMetrics(
+            cpuPct: DeviceMetrics::clampPct($this->cpu($host, $community, $profile)),
+            memUsedPct: DeviceMetrics::clampPct($this->memory($host, $community, $profile)),
+            tempC: $this->temperature($host, $community, $profile),
+        );
+    }
+
+    /** @param array<string, mixed> $profile */
+    private function cpu(string $host, string $community, array $profile): ?float
+    {
+        if (! empty($profile['cpu_walk'])) {
+            $loads = $this->numericValues($this->snmp->walk($host, $community, (string) $profile['cpu_walk']));
+
+            return $loads === [] ? null : array_sum($loads) / count($loads); // average across cores
+        }
+
+        foreach ((array) ($profile['cpu_oids'] ?? []) as $oid) {
+            $res = $this->snmp->get($host, $community, [$oid]);
+            $val = $this->firstNumeric($res);
+            if ($val !== null) {
+                return $val;
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $profile */
+    private function memory(string $host, string $community, array $profile): ?float
+    {
+        return match ($profile['mem'] ?? null) {
+            'hrstorage' => $this->hrStorageMemory($host, $community),
+            'cisco' => $this->ciscoMemory($host, $community, $profile),
+            default => null,
+        };
+    }
+
+    /**
+     * Host-resources-MIB memory: walk the storage table, pick the physical-RAM row
+     * (largest size among memory rows, skipping virtual/swap/cache), used/size %.
+     */
+    private function hrStorageMemory(string $host, string $community): ?float
+    {
+        $oids = config('mymate.device_metrics.hrstorage', []);
+        $descr = $this->snmp->walk($host, $community, (string) $oids['descr']);
+        $size = $this->numericValues($this->snmp->walk($host, $community, (string) $oids['size']));
+        $used = $this->numericValues($this->snmp->walk($host, $community, (string) $oids['used']));
+
+        $bestIndex = null;
+        $bestSize = 0.0;
+        foreach ($descr as $index => $label) {
+            $l = strtolower((string) $label);
+            $isRam = str_contains($l, 'physical memory') || str_contains($l, 'real memory')
+                || str_contains($l, 'main memory') || $l === 'memory'
+                || (str_contains($l, 'ram') && ! str_contains($l, 'virtual'));
+            $isRam = $isRam && ! str_contains($l, 'virtual') && ! str_contains($l, 'swap')
+                && ! str_contains($l, 'cache') && ! str_contains($l, 'buffer');
+
+            if ($isRam && isset($size[$index]) && $size[$index] > $bestSize) {
+                $bestSize = $size[$index];
+                $bestIndex = $index;
+            }
+        }
+
+        if ($bestIndex === null || $bestSize <= 0 || ! isset($used[$bestIndex])) {
+            return null;
+        }
+
+        return ($used[$bestIndex] / $bestSize) * 100;
+    }
+
+    /** Cisco memory pools: sum used / (used + free) across pools. */
+    private function ciscoMemory(string $host, string $community, array $profile): ?float
+    {
+        $used = $this->numericValues($this->snmp->walk($host, $community, (string) $profile['mem_used_walk']));
+        $free = $this->numericValues($this->snmp->walk($host, $community, (string) $profile['mem_free_walk']));
+
+        $totalUsed = array_sum($used);
+        $totalFree = array_sum($free);
+        $total = $totalUsed + $totalFree;
+
+        return $total > 0 ? ($totalUsed / $total) * 100 : null;
+    }
+
+    /** @param array<string, mixed> $profile */
+    private function temperature(string $host, string $community, array $profile): ?float
+    {
+        $divisor = max(1, (int) ($profile['temp_divisor'] ?? 1));
+        $values = [];
+
+        if (! empty($profile['temp_walk'])) {
+            $values = $this->numericValues($this->snmp->walk($host, $community, (string) $profile['temp_walk']));
+        }
+        foreach ((array) ($profile['temp_oids'] ?? []) as $oid) {
+            $values = [...$values, ...$this->numericValues($this->snmp->get($host, $community, [$oid]))];
+        }
+
+        // Ignore obvious non-readings (0 / sentinel) - take the hottest real sensor.
+        $values = array_filter($values, static fn (float $v): bool => $v > 0);
+
+        return $values === [] ? null : max($values) / $divisor;
+    }
+
+    /**
+     * Resolve host + decrypted community. Mirrors SnmpThroughputDriver so a metrics
+     * poll and a throughput poll fail the same way on a missing community.
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function target(Device $device): array
+    {
+        $device->loadMissing('credential');
+        $community = $device->credential?->snmp_community;
+
+        if ($community === null || $community === '') {
+            throw new SnmpClientException("Device {$device->id} ({$device->name}) has no SNMP community.");
+        }
+
+        return [$device->mgmt_ip, $community];
+    }
+
+    /**
+     * Keep only numeric SNMP values, cast to float, preserving keys.
+     *
+     * @param  array<string, string>  $values
+     * @return array<string, float>
+     */
+    private function numericValues(array $values): array
+    {
+        $out = [];
+        foreach ($values as $index => $value) {
+            if (is_numeric($value)) {
+                $out[$index] = (float) $value;
+            }
+        }
+
+        return $out;
+    }
+
+    /** @param array<string, string> $values */
+    private function firstNumeric(array $values): ?float
+    {
+        foreach ($values as $value) {
+            if (is_numeric($value)) {
+                return (float) $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Support/BackupSchedule.php
+++ b/app/Support/BackupSchedule.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Setting;
+use Illuminate\Support\Carbon;
+
+/**
+ * Operator-configurable schedule for automatic config backups. Stored in one `settings`
+ * row; the scheduler calls `mymate:backup:run --scheduled` hourly and this decides whether
+ * a run is due, so the cadence changes take effect without restarting the scheduler.
+ *
+ * Defaults to daily at 02:00 (the previous hard-coded behaviour) when nothing is stored.
+ */
+class BackupSchedule
+{
+    private const KEY = 'backup.schedule';
+
+    /** @var list<string> */
+    public const FREQUENCIES = ['hourly', 'every_6h', 'every_12h', 'daily', 'weekly'];
+
+    /** @return array{enabled:bool, frequency:string, hour:int, weekday:int, last_run_at:?string} */
+    public function get(): array
+    {
+        $c = Setting::where('key', self::KEY)->first()?->value ?? [];
+
+        return [
+            'enabled' => (bool) ($c['enabled'] ?? true),
+            'frequency' => in_array($c['frequency'] ?? null, self::FREQUENCIES, true) ? $c['frequency'] : 'daily',
+            'hour' => (int) ($c['hour'] ?? 2),
+            'weekday' => (int) ($c['weekday'] ?? 0), // 0 = Sunday
+            'last_run_at' => $c['last_run_at'] ?? null,
+        ];
+    }
+
+    /** @param array<string,mixed> $input */
+    public function save(array $input): void
+    {
+        $current = $this->get();
+        Setting::updateOrCreate(['key' => self::KEY], [
+            'type' => 'backup',
+            'value' => [
+                'enabled' => (bool) ($input['enabled'] ?? $current['enabled']),
+                'frequency' => in_array($input['frequency'] ?? null, self::FREQUENCIES, true) ? $input['frequency'] : $current['frequency'],
+                'hour' => max(0, min(23, (int) ($input['hour'] ?? $current['hour']))),
+                'weekday' => max(0, min(6, (int) ($input['weekday'] ?? $current['weekday']))),
+                'last_run_at' => $current['last_run_at'], // preserved across edits
+            ],
+        ]);
+    }
+
+    /** Whether a scheduled run should fire at $now (the command is invoked hourly). */
+    public function due(Carbon $now): bool
+    {
+        $c = $this->get();
+        if (! $c['enabled']) {
+            return false;
+        }
+        $last = $c['last_run_at'] ? Carbon::parse($c['last_run_at']) : null;
+
+        return match ($c['frequency']) {
+            'hourly' => $last === null || $last->lt($now->copy()->startOfHour()),
+            'every_6h' => $last === null || $last->lte($now->copy()->subHours(6)),
+            'every_12h' => $last === null || $last->lte($now->copy()->subHours(12)),
+            'weekly' => $now->dayOfWeek === $c['weekday'] && $now->hour === $c['hour']
+                && ($last === null || $last->lt($now->copy()->startOfWeek())),
+            default /* daily */ => $now->hour === $c['hour'] && ($last === null || $last->lt($now->copy()->startOfDay())),
+        };
+    }
+
+    /** Record that a scheduled run fired, so `due()` won't fire again this period. */
+    public function markRan(Carbon $now): void
+    {
+        $row = Setting::firstOrNew(['key' => self::KEY]);
+        $value = $row->value ?? [];
+        $value['last_run_at'] = $now->toIso8601String();
+        $row->type = 'backup';
+        $row->value = $value;
+        $row->save();
+    }
+}

--- a/app/Support/DeviceHierarchy.php
+++ b/app/Support/DeviceHierarchy.php
@@ -24,14 +24,30 @@ class DeviceHierarchy
      */
     public function orderDownstreamFirst(array $deviceIds): array
     {
+        $depths = $this->depths();
+        $depth = fn (int $id): int => $depths[$id] ?? 0;
+
+        $ids = array_values(array_unique(array_map('intval', $deviceIds)));
+        usort($ids, fn (int $a, int $b): int => $depth($b) <=> $depth($a) ?: $a <=> $b);
+
+        return $ids;
+    }
+
+    /**
+     * Hops-to-root depth for every device (via `parent_device_id`). A leaf/CPE has the
+     * highest depth, the core the lowest - the "distance" a rolling upgrade orders by.
+     * Cycle-guarded.
+     *
+     * @return array<int, int> id => depth
+     */
+    public function depths(): array
+    {
         /** @var array<int, int|null> $parents id => parent_device_id */
         $parents = Device::query()->pluck('parent_device_id', 'id')->all();
 
-        $depthCache = [];
-        $depth = function (int $id) use ($parents, &$depthCache): int {
-            if (isset($depthCache[$id])) {
-                return $depthCache[$id];
-            }
+        $cache = [];
+        foreach (array_keys($parents) as $id) {
+            $id = (int) $id;
             $d = 0;
             $seen = [];
             $cur = $id;
@@ -43,13 +59,9 @@ class DeviceHierarchy
                 $cur = (int) $parents[$cur];
                 $d++;
             }
+            $cache[$id] = $d;
+        }
 
-            return $depthCache[$id] = $d;
-        };
-
-        $ids = array_values(array_unique(array_map('intval', $deviceIds)));
-        usort($ids, fn (int $a, int $b): int => $depth($b) <=> $depth($a) ?: $a <=> $b);
-
-        return $ids;
+        return $cache;
     }
 }

--- a/app/Support/RustedDrivers.php
+++ b/app/Support/RustedDrivers.php
@@ -20,6 +20,7 @@ class RustedDrivers
     /** Every driver Rusted ships (github.com/JoshFinlayAU/rusted -> docs/drivers.md). */
     public const ALL = [
         'mikrotik_routeros',
+        'mikrotik_routeros_api',
         'cisco_nxos',
         'juniper_junos',
         'cisco_ios',

--- a/app/Support/RustedDrivers.php
+++ b/app/Support/RustedDrivers.php
@@ -20,7 +20,6 @@ class RustedDrivers
     /** Every driver Rusted ships (github.com/JoshFinlayAU/rusted -> docs/drivers.md). */
     public const ALL = [
         'mikrotik_routeros',
-        'mikrotik_routeros_api',
         'cisco_nxos',
         'juniper_junos',
         'cisco_ios',

--- a/config/mymate.php
+++ b/config/mymate.php
@@ -75,6 +75,62 @@ return [
         ],
     ],
 
+    // Device resource metrics - CPU / memory / temperature. Polled on their own
+    // (slower) cadence than throughput; latest values cached on the device row and
+    // trend samples appended to device_metric_samples. Off by env if you don't want it.
+    'device_metrics' => [
+        'enabled' => (bool) env('MYMATE_DEVICE_METRICS', true),
+        // Seconds between metric polls. Slower than throughput - cpu/mem/temp move
+        // gradually and the SNMP walks (hrProcessorLoad, hrStorage) aren't free.
+        'interval' => (int) env('MYMATE_DEVICE_METRICS_INTERVAL', 30),
+        'broadcast' => (bool) env('MYMATE_BROADCAST_METRICS', true),
+
+        // Per-vendor SNMP OID profiles. Picked by a case-insensitive substring match on
+        // the device's detected `vendor` (CaptureDeviceFacts), falling back to `default`
+        // (host-resources MIB) for anything unmatched. Each profile declares how to read
+        // each metric; unsupported metrics are just left null.
+        //
+        //   cpu_walk    walk this column and average the numeric values -> cpu %
+        //   cpu_oids    GET these scalars, first numeric wins -> cpu %
+        //   mem         'hrstorage' (host-MIB storage, RAM row) | 'cisco' (pool used/free)
+        //   mem_*_walk  used/free columns for the 'cisco' strategy
+        //   temp_oids   GET these scalars, take the max -> temp (÷ temp_divisor)
+        //   temp_walk   walk this column, take the max -> temp (÷ temp_divisor)
+        'profiles' => [
+            'mikrotik' => [
+                'cpu_walk' => '.1.3.6.1.2.1.25.3.3.1.2',   // hrProcessorLoad
+                'mem' => 'hrstorage',
+                // mtxrHlProcessorTemperature, then board temperature (whichever answers).
+                'temp_oids' => ['.1.3.6.1.4.1.14988.1.1.3.11.0', '.1.3.6.1.4.1.14988.1.1.3.10.0'],
+                'temp_divisor' => 1,
+            ],
+            'cisco' => [
+                'cpu_oids' => ['.1.3.6.1.4.1.9.9.109.1.1.1.1.7.1'], // cpmCPUTotal5minRev
+                'mem' => 'cisco',
+                'mem_used_walk' => '.1.3.6.1.4.1.9.9.48.1.1.1.5',   // ciscoMemoryPoolUsed
+                'mem_free_walk' => '.1.3.6.1.4.1.9.9.48.1.1.1.6',   // ciscoMemoryPoolFree
+                'temp_walk' => '.1.3.6.1.4.1.9.9.13.1.3.1.3',       // ciscoEnvMonTemperatureValue
+                'temp_divisor' => 1,
+            ],
+            // Host-resources MIB - net-snmp/Linux/Windows servers and anything that
+            // implements it. No portable temperature OID, so temp stays null here.
+            'default' => [
+                'cpu_walk' => '.1.3.6.1.2.1.25.3.3.1.2',   // hrProcessorLoad
+                'mem' => 'hrstorage',
+                'temp_oids' => [],
+                'temp_divisor' => 1,
+            ],
+        ],
+
+        // host-MIB storage columns for the 'hrstorage' memory strategy - walk descr to
+        // find the physical-RAM row, then used/size. Swap/virtual/cached rows are skipped.
+        'hrstorage' => [
+            'descr' => '.1.3.6.1.2.1.25.2.3.1.3',  // hrStorageDescr
+            'size' => '.1.3.6.1.2.1.25.2.3.1.5',   // hrStorageSize (in alloc units)
+            'used' => '.1.3.6.1.2.1.25.2.3.1.6',   // hrStorageUsed
+        ],
+    ],
+
     // Auto-discovery. A separate `scan` worker sweeps authorized subnets,
     // probes responders against the credential pool, and queues matches for review.
     // Safety (NFR-10): bounded blast radius + lockout-aware credential trials.

--- a/database/factories/CredentialFactory.php
+++ b/database/factories/CredentialFactory.php
@@ -33,4 +33,15 @@ class CredentialFactory extends Factory
             'password' => fake()->password(),
         ]);
     }
+
+    /** An SSH credential (user/pass) for config backups. */
+    public function ssh(): static
+    {
+        return $this->state(fn () => [
+            'type' => 'ssh',
+            'snmp_community' => null,
+            'username' => fake()->userName(),
+            'password' => fake()->password(),
+        ]);
+    }
 }

--- a/database/migrations/2026_07_12_000001_allow_null_link_interfaces.php
+++ b/database/migrations/2026_07_12_000001_allow_null_link_interfaces.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Allow a link end to carry no interface, so a ping-only device (poll_method=none, no
+ * discovered interfaces) can still be linked into the topology from the other end. The
+ * link's throughput/util then comes from whichever end does have an interface.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Either end may now be null (the ping-only end). Device ids stay required.
+        DB::statement('ALTER TABLE links ALTER COLUMN a_interface_id DROP NOT NULL');
+        DB::statement('ALTER TABLE links ALTER COLUMN b_interface_id DROP NOT NULL');
+
+        // The old unique(a_interface_id, b_interface_id) can't express "only when both are
+        // set" (Postgres treats NULLs as distinct, so it wouldn't catch duplicate ping-only
+        // links anyway). Replace it with a partial unique index that keeps the no-duplicate
+        // guarantee for real interface-to-interface links; null-ended links are deduped in
+        // the Form Request instead.
+        DB::statement('ALTER TABLE links DROP CONSTRAINT IF EXISTS links_a_interface_id_b_interface_id_unique');
+        DB::statement('DROP INDEX IF EXISTS links_a_interface_id_b_interface_id_unique');
+        DB::statement(<<<'SQL'
+            CREATE UNIQUE INDEX links_iface_pair_unique ON links (a_interface_id, b_interface_id)
+            WHERE a_interface_id IS NOT NULL AND b_interface_id IS NOT NULL
+        SQL);
+
+        // Only enforce interface-belongs-to-device for ends that actually have an interface.
+        DB::unprepared(<<<'SQL'
+            CREATE OR REPLACE FUNCTION links_interface_belongs_to_device()
+            RETURNS trigger AS $$
+            BEGIN
+                IF NEW.a_interface_id IS NOT NULL
+                   AND (SELECT device_id FROM interfaces WHERE id = NEW.a_interface_id) IS DISTINCT FROM NEW.a_device_id THEN
+                    RAISE EXCEPTION 'a_interface_id % does not belong to a_device_id %', NEW.a_interface_id, NEW.a_device_id;
+                END IF;
+                IF NEW.b_interface_id IS NOT NULL
+                   AND (SELECT device_id FROM interfaces WHERE id = NEW.b_interface_id) IS DISTINCT FROM NEW.b_device_id THEN
+                    RAISE EXCEPTION 'b_interface_id % does not belong to b_device_id %', NEW.b_interface_id, NEW.b_device_id;
+                END IF;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+        SQL);
+    }
+
+    public function down(): void
+    {
+        // Restore the strict belongs-check (no null guard).
+        DB::unprepared(<<<'SQL'
+            CREATE OR REPLACE FUNCTION links_interface_belongs_to_device()
+            RETURNS trigger AS $$
+            BEGIN
+                IF (SELECT device_id FROM interfaces WHERE id = NEW.a_interface_id) IS DISTINCT FROM NEW.a_device_id THEN
+                    RAISE EXCEPTION 'a_interface_id % does not belong to a_device_id %', NEW.a_interface_id, NEW.a_device_id;
+                END IF;
+                IF (SELECT device_id FROM interfaces WHERE id = NEW.b_interface_id) IS DISTINCT FROM NEW.b_device_id THEN
+                    RAISE EXCEPTION 'b_interface_id % does not belong to b_device_id %', NEW.b_interface_id, NEW.b_device_id;
+                END IF;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+        SQL);
+
+        DB::statement('DROP INDEX IF EXISTS links_iface_pair_unique');
+        // These fail if any null-ended links exist; that's expected on a rollback.
+        DB::statement('ALTER TABLE links ALTER COLUMN a_interface_id SET NOT NULL');
+        DB::statement('ALTER TABLE links ALTER COLUMN b_interface_id SET NOT NULL');
+        DB::statement('ALTER TABLE links ADD CONSTRAINT links_a_interface_id_b_interface_id_unique UNIQUE (a_interface_id, b_interface_id)');
+    }
+};

--- a/database/migrations/2026_07_12_000002_add_device_metrics.php
+++ b/database/migrations/2026_07_12_000002_add_device_metrics.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Device resource metrics - CPU / memory / temperature. Live latest values live on the
+ * device row (the fast path the map tile reads, mirroring interfaces.util_*); the trend
+ * window is a RANGE-partitioned append table like interface_samples, dropped by day for
+ * retention (App\Actions\History\ManageHistoryPartitions rolls both tables).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table): void {
+            $table->double('cpu_pct')->nullable();       // 0-100
+            $table->double('mem_used_pct')->nullable();  // 0-100
+            $table->double('temp_c')->nullable();        // celsius
+            $table->timestamp('metrics_at')->nullable(); // last successful metrics poll
+        });
+
+        DB::statement(<<<'SQL'
+            CREATE TABLE device_metric_samples (
+                device_id bigint NOT NULL,
+                ts timestamp(0) without time zone NOT NULL,
+                cpu_pct double precision,
+                mem_used_pct double precision,
+                temp_c double precision
+            ) PARTITION BY RANGE (ts)
+        SQL);
+
+        DB::statement('CREATE INDEX device_metric_samples_device_ts_idx ON device_metric_samples (device_id, ts)');
+
+        // Seed [yesterday .. +3 days] so writes work right after migrate.
+        $day = now()->startOfDay()->subDay();
+        for ($i = 0; $i < 5; $i++) {
+            $date = $day->copy()->addDays($i);
+            $name = 'device_metric_samples_'.$date->format('Ymd');
+            $from = $date->format('Y-m-d 00:00:00');
+            $to = $date->copy()->addDay()->format('Y-m-d 00:00:00');
+            DB::statement("CREATE TABLE IF NOT EXISTS \"{$name}\" PARTITION OF device_metric_samples FOR VALUES FROM ('{$from}') TO ('{$to}')");
+        }
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP TABLE IF EXISTS device_metric_samples CASCADE');
+
+        Schema::table('devices', function (Blueprint $table): void {
+            $table->dropColumn(['cpu_pct', 'mem_used_pct', 'temp_c', 'metrics_at']);
+        });
+    }
+};

--- a/database/migrations/2026_07_13_000001_add_ssh_credential_to_devices.php
+++ b/database/migrations/2026_07_13_000001_add_ssh_credential_to_devices.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * A dedicated SSH credential per device for config backups, separate from the SNMP/RouterOS
+ * credential used for polling. Nullable - backups fall back to the device's poll credential
+ * (if SSH-usable) then the Settings default, as before.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table): void {
+            $table->foreignId('ssh_credential_id')->nullable()->after('credential_id')
+                ->constrained('credentials')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('ssh_credential_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_13_000002_add_private_key_to_credentials.php
+++ b/database/migrations/2026_07_13_000002_add_private_key_to_credentials.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * An SSH private key on a credential, for key-based SSH (e.g. a key My Mate had Rusted
+ * install on a MikroTik over the API). Encrypted at rest like the other secrets.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('credentials', function (Blueprint $table): void {
+            $table->text('private_key')->nullable()->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('credentials', function (Blueprint $table): void {
+            $table->dropColumn('private_key');
+        });
+    }
+};

--- a/deploy/build/build-deb.sh
+++ b/deploy/build/build-deb.sh
@@ -33,6 +33,10 @@ ARCH="${ARCH:-amd64}"
 # regenerate with build-fping.sh. Falls back to a system build if the vendored one is absent.
 FPING_BIN="${FPING_BIN:-$SCRIPT_DIR/vendor/fping}"
 [ -f "$FPING_BIN" ] || FPING_BIN=/usr/local/sbin/fping
+# Optional Rusted backup-engine binary. When present it's bundled to /usr/local/bin/rusted
+# and postinst auto-provisions backups; when absent the package still installs fine (backups
+# just start unconfigured). Build it with deploy/rusted/build-rusted.sh.
+RUSTED_BIN="${RUSTED_BIN:-$REPO_ROOT/deploy/rusted/vendor/rusted}"
 REVERB_KEY="${REVERB_KEY:-mymate}"
 PHP_VERSION="${PHP_VERSION:-8.4}"
 
@@ -71,6 +75,7 @@ tar -C "$REPO_ROOT" \
     --exclude='./build' \
     --exclude='./dist' \
     --exclude='./deploy/build' \
+    --exclude='./deploy/rusted/vendor' \
     --exclude='./vendor' \
     --exclude='./agent' \
     --exclude='./PRD.md' \
@@ -125,6 +130,13 @@ say "Building frontend assets"
 # --- 4. System files into the stage --------------------------------------
 say "Laying system files (systemd, nginx, php-fpm, fping)"
 install -Dm755 "$FPING_BIN"                       "$STAGE/usr/local/sbin/fping"
+# Rusted backup engine (optional) - postinst runs deploy/rusted/provision.sh to wire it up.
+if [ -f "$RUSTED_BIN" ]; then
+    install -Dm755 "$RUSTED_BIN"                  "$STAGE/usr/local/bin/rusted"
+    say "Bundled the Rusted backup engine"
+else
+    warn "Rusted binary not found ($RUSTED_BIN) - backups will need manual setup. Build it with deploy/rusted/build-rusted.sh."
+fi
 install -Dm644 "$FILES_DIR/nginx-mymate.conf"     "$STAGE/etc/nginx/sites-available/mymate"
 # Pristine copy mymate-ssl reads to revert to plain HTTP (methods 1 & 2, and LXC reset) -
 # deploy/build is excluded from the app tree, so the helper can't read it from there.

--- a/deploy/build/build-lxc.sh
+++ b/deploy/build/build-lxc.sh
@@ -77,6 +77,11 @@ $PODMAN exec "$NAME" bash -c '
     # first-boot flips it back to self-signed HTTPS for the real host.
     rm -rf /etc/mymate/tls 2>/dev/null || true
     cp /usr/share/mymate/nginx-mymate.conf /etc/nginx/sites-available/mymate 2>/dev/null || true
+    # Strip the baked Rusted token + backup data so every clone gets its own on first boot
+    # (the binary stays; first-boot re-runs provision.sh to regenerate config + rewire).
+    systemctl disable rusted-api >/dev/null 2>&1 || true
+    rm -f /etc/rusted/config.toml 2>/dev/null || true
+    rm -rf /var/lib/rusted/rusted.db /var/lib/rusted/backups 2>/dev/null || true
 '
 
 # --- 4. export the rootfs as a Proxmox template --------------------------

--- a/deploy/build/files/firstboot.sh
+++ b/deploy/build/files/firstboot.sh
@@ -59,6 +59,14 @@ MYMATE_SSL_NO_RESTART=1 mymate-ssl self-signed "${SSL_HOST:-}" >/dev/null 2>&1 \
 as_app "php artisan migrate --force --no-interaction" || true
 as_app "php artisan config:clear" || true
 
+# 4b. Re-provision the backup engine so this instance gets its OWN rusted token + backup
+# repo (the template's were stripped by the LXC build). Only touches rusted-api, not the
+# engine services this unit is ordered Before=, so no deadlock. Best-effort.
+if [ -x /usr/local/bin/rusted ] && [ -f "$APP/deploy/rusted/provision.sh" ]; then
+    APP_DIR="$APP" APP_USER=mymate bash "$APP/deploy/rusted/provision.sh" \
+        || echo "my-mate: WARNING backup engine setup failed - configure it later in Settings." >&2
+fi
+
 touch "$MARKER"
 
 # php-fpm may have started before us; it re-reads .env per request, but restart it for a

--- a/deploy/build/package/postinst
+++ b/deploy/build/package/postinst
@@ -139,6 +139,16 @@ ICMPERR
         systemctl restart "$svc" >/dev/null 2>&1 || true
     done
 
+    # --- 7c. backup engine (Rusted) -------------------------------------
+    # If the bundled rusted binary is present, provision it (loopback API + generated
+    # token) and wire My Mate up so device backups work out of the box. Best-effort:
+    # backups are optional, so a failure here must never fail the install.
+    if [ -x /usr/local/bin/rusted ] && [ -f "$APP/deploy/rusted/provision.sh" ]; then
+        echo "my-mate: provisioning the Rusted backup engine"
+        APP_DIR="$APP" APP_USER="$RUN_USER" bash "$APP/deploy/rusted/provision.sh" \
+            || echo "my-mate: WARNING backup engine setup failed - configure it later in Settings." >&2
+    fi
+
     # --- 7b. HTTPS by default (self-signed) - encrypt day-1 traffic -----
     # Secure before the admin ever logs in: a per-instance self-signed cert so the console
     # (and the /agent tunnel) is HTTPS out of the box. The operator upgrades to a trusted

--- a/deploy/rusted/README.md
+++ b/deploy/rusted/README.md
@@ -23,6 +23,23 @@ inspector shows it without hitting Rusted on every render.
 
 ---
 
+## Automatic (the packages do this for you)
+
+The `.deb`, the Proxmox LXC template and the Docker image **bundle the rusted binary and
+provision it on install** - a loopback API on `:8410` with a generated token, wired into My
+Mate - so backups just work with no setup. The LXC/Docker paths regenerate the token
+per-instance so clones never share one. You only need the manual steps below when running
+**from source**, or to re-provision by hand:
+
+```sh
+sudo deploy/rusted/provision.sh          # build/install rusted, config, service, wire My Mate
+# (uses a bundled binary if present via RUSTED_BIN, else builds from RUSTED_SRC)
+```
+
+The rest of this doc is the manual/from-source path and the reference for how it all fits.
+
+---
+
 ## 1. Install the Rusted sidecar
 
 Rusted isn't bundled (it's a separate Go binary). Build + install it once on the My Mate host:

--- a/deploy/rusted/build-rusted.sh
+++ b/deploy/rusted/build-rusted.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Build the Rusted backup-engine binary so build-deb.sh (and the Docker image) can bundle
+# it - backups then work out of the box instead of needing a manual install. Rusted is a
+# separate Go project (github.com/JoshFinlayAU/rusted); this clones + builds it statically.
+#
+#   deploy/rusted/build-rusted.sh                # -> deploy/rusted/vendor/rusted
+#   OUT=/tmp/rusted deploy/rusted/build-rusted.sh
+#
+# Needs Go (1.26+ is fetched automatically via GOTOOLCHAIN=auto) + git.
+set -euo pipefail
+
+REPO="${RUSTED_REPO:-https://github.com/JoshFinlayAU/rusted.git}"
+REF="${RUSTED_REF:-main}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="${OUT:-$SCRIPT_DIR/vendor/rusted}"
+
+say() { printf '\033[36m==>\033[0m %s\n' "$*"; }
+
+command -v go >/dev/null 2>&1 || { echo "error: Go toolchain not found (needed to build rusted)." >&2; exit 1; }
+command -v git >/dev/null 2>&1 || { echo "error: git not found." >&2; exit 1; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+say "Cloning rusted ($REF)"
+git clone --depth 1 --branch "$REF" "$REPO" "$WORK/rusted" 2>/dev/null \
+    || git clone --depth 1 "$REPO" "$WORK/rusted"
+
+say "Building (Go auto-fetches the toolchain if needed)"
+( cd "$WORK/rusted" && CGO_ENABLED=0 GOTOOLCHAIN=auto go build -trimpath -o "$WORK/rusted-bin" ./cmd/rusted )
+
+mkdir -p "$(dirname "$OUT")"
+install -m0755 "$WORK/rusted-bin" "$OUT"
+say "Built $OUT ($("$OUT" --help >/dev/null 2>&1 && echo ok || echo '?'))"

--- a/deploy/rusted/provision.sh
+++ b/deploy/rusted/provision.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Provision the Rusted config-backup engine for My Mate and wire My Mate up to it, so
+# device backups work out of the box. Idempotent - safe to re-run. Needs root (or sudo).
+#
+# The rusted binary is resolved in this order:
+#   1. an already-installed /usr/local/bin/rusted
+#   2. $RUSTED_BIN            - a prebuilt binary to install (what the packages ship)
+#   3. build from $RUSTED_SRC - a rusted source checkout (needs Go 1.26+)
+#
+# After provisioning it reads the generated API token back out of the config and saves it
+# into My Mate (encrypted), so no manual Settings step is needed.
+#
+# Env knobs: RUSTED_PORT (default 8410), APP_DIR (default /opt/mymate),
+#            APP_USER (user to run artisan as; default: the owner of APP_DIR).
+set -euo pipefail
+
+RUSTED_PORT="${RUSTED_PORT:-8410}"
+RUSTED_ADDR="127.0.0.1:${RUSTED_PORT}"
+APP_DIR="${APP_DIR:-/opt/mymate}"
+BIN=/usr/local/bin/rusted
+CONFIG=/etc/rusted/config.toml
+DATA=/var/lib/rusted
+
+SUDO=""; [ "$(id -u)" -eq 0 ] || SUDO=sudo
+say() { printf '\033[36m==>\033[0m %s\n' "$*"; }
+
+# --- 1. binary ---------------------------------------------------------------
+if [ -x "$BIN" ]; then
+    say "rusted already installed at $BIN"
+elif [ -n "${RUSTED_BIN:-}" ] && [ -f "${RUSTED_BIN:-}" ]; then
+    say "Installing bundled rusted binary"
+    $SUDO install -Dm0755 "$RUSTED_BIN" "$BIN"
+elif [ -n "${RUSTED_SRC:-}" ] && [ -d "${RUSTED_SRC:-}" ]; then
+    say "Building rusted from source ($RUSTED_SRC)"
+    command -v go >/dev/null 2>&1 || { echo "error: Go toolchain needed to build rusted" >&2; exit 1; }
+    tmp="$(mktemp)"
+    ( cd "$RUSTED_SRC" && CGO_ENABLED=0 GOTOOLCHAIN=auto go build -o "$tmp" ./cmd/rusted )
+    $SUDO install -Dm0755 "$tmp" "$BIN"
+    rm -f "$tmp"
+else
+    echo "error: no rusted binary. Set RUSTED_BIN=<prebuilt> or RUSTED_SRC=<checkout>." >&2
+    exit 1
+fi
+
+# --- 2. dedicated user + data dirs ------------------------------------------
+if ! id rusted >/dev/null 2>&1; then
+    say "Creating the rusted system user"
+    $SUDO useradd --system --home "$DATA" --shell /usr/sbin/nologin rusted
+fi
+$SUDO mkdir -p "$DATA/backups" /etc/rusted
+
+# --- 3. config (generated once, then left alone) ----------------------------
+if [ ! -f "$CONFIG" ]; then
+    say "Generating config with a random API token + secret"
+    $SUDO "$BIN" config init --global --data-dir "$DATA"
+    # Rusted defaults to :8080 which clashes with Reverb - bind loopback:8410 instead.
+    $SUDO sed -i "s|^api_addr\s*=.*|api_addr  = \"${RUSTED_ADDR}\"|" "$CONFIG"
+else
+    say "Config already at $CONFIG (leaving it untouched)"
+fi
+
+# --- 4. init db + backup git repo, then hand ownership to the rusted user ----
+say "Initialising database + backup git repository"
+$SUDO "$BIN" --config "$CONFIG" init || true
+$SUDO chown -R rusted:rusted "$DATA"
+$SUDO chown root:rusted "$CONFIG"
+$SUDO chmod 640 "$CONFIG"
+
+# --- 5. service --------------------------------------------------------------
+if command -v systemctl >/dev/null 2>&1; then
+    say "Installing + starting the rusted-api service"
+    $SUDO install -m0644 "$APP_DIR/deploy/rusted/rusted-api.service" /etc/systemd/system/rusted-api.service
+    $SUDO systemctl daemon-reload
+    $SUDO systemctl enable --now rusted-api
+else
+    say "No systemd here - start rusted yourself: $BIN --config $CONFIG serve"
+fi
+
+# --- 6. health check ---------------------------------------------------------
+for i in $(seq 1 10); do
+    if curl -fsS "http://${RUSTED_ADDR}/healthz" >/dev/null 2>&1; then
+        say "Rusted is healthy on http://${RUSTED_ADDR}"
+        break
+    fi
+    sleep 1
+    [ "$i" -eq 10 ] && { echo "error: rusted did not answer /healthz on ${RUSTED_ADDR}" >&2; exit 1; }
+done
+
+# --- 7. wire My Mate up to it (saves the token into My Mate, encrypted) ------
+# Read the token as root (the config is root:rusted 640, so the app user can't) and
+# hand it to artisan run as the app user - the app user never needs to read /etc/rusted.
+if [ -f "$APP_DIR/artisan" ]; then
+    APP_USER="${APP_USER:-$(stat -c '%U' "$APP_DIR")}"
+    TOKEN="$($SUDO grep -oP '^\s*api_token\s*=\s*"\K[^"]+' "$CONFIG" || true)"
+    if [ -n "$TOKEN" ]; then
+        say "Configuring My Mate to use it (as ${APP_USER})"
+        $SUDO -u "$APP_USER" php "$APP_DIR/artisan" mymate:backup:configure \
+            --url "http://${RUSTED_ADDR}" --token "$TOKEN"
+    else
+        echo "warning: couldn't read api_token from $CONFIG - set it in Settings manually." >&2
+    fi
+fi
+
+say "Done. Device backups are ready - enable them per device in the inspector."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -53,5 +53,23 @@ php artisan migrate --force || echo "mymate: migrate failed - will retry next bo
 php artisan config:clear >/dev/null 2>&1 || true
 chown -R www-data:www-data storage bootstrap/cache 2>/dev/null || true
 
+# Backup engine (Rusted): generate a config with its own token on first start, init the
+# db + git backup repo, and point My Mate at it so backups just work. Mount /etc/rusted and
+# /var/lib/rusted as volumes to keep the token + captured configs across container recreation
+# (otherwise a fresh token is generated each start - harmless, My Mate is re-pointed below).
+if [ -x /usr/local/bin/rusted ]; then
+    if [ ! -f /etc/rusted/config.toml ]; then
+        echo "mymate: initialising the Rusted backup engine"
+        rusted config init --global --data-dir /var/lib/rusted >/dev/null 2>&1 || true
+        # Rusted defaults to :8080 (taken by Reverb here) - bind loopback:8410 instead.
+        sed -i 's|^api_addr[[:space:]]*=.*|api_addr  = "127.0.0.1:8410"|' /etc/rusted/config.toml 2>/dev/null || true
+        rusted --config /etc/rusted/config.toml init >/dev/null 2>&1 || true
+        chown -R www-data:www-data /etc/rusted /var/lib/rusted 2>/dev/null || true
+    fi
+    # Always re-point My Mate at the current token so the two never drift apart.
+    php artisan mymate:backup:configure --url http://127.0.0.1:8410 --from-rusted /etc/rusted/config.toml >/dev/null 2>&1 \
+        || echo "mymate: backup engine not auto-configured - set it in Settings"
+fi
+
 echo "mymate: starting services"
 exec "$@"

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -24,6 +24,16 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
+[program:rusted]
+command=/usr/local/bin/rusted --config /etc/rusted/config.toml serve
+user=www-data
+autorestart=true
+priority=15
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
 [program:reverb]
 command=php /app/artisan reverb:start --host=0.0.0.0 --port=8080
 user=www-data

--- a/resources/js/features/alerts/components/AlertsView.tsx
+++ b/resources/js/features/alerts/components/AlertsView.tsx
@@ -167,7 +167,7 @@ function PolicyForm({ initial, transports, onDone }: { initial?: AlertPolicy; tr
                         <span>
                             Suppress dependents
                             <span className="mt-0.5 block text-[11px] text-white/35">
-                                Don\'t alert on devices behind a down parent - only the root-cause device fires.
+                                Don't alert on devices behind a down parent - only the root-cause device fires.
                             </span>
                         </span>
                         <input
@@ -469,7 +469,7 @@ export function AlertsView() {
                     icon={<Trash weight="light" className="h-5 w-5" />}
                     message={
                         <>
-                            Delete the policy <span className="font-semibold text-white/85">{deletingPolicy.name}</span>? This can\'t be undone.
+                            Delete the policy <span className="font-semibold text-white/85">{deletingPolicy.name}</span>? This can't be undone.
                         </>
                     }
                     confirmLabel="Delete"

--- a/resources/js/features/backups/api/backups.ts
+++ b/resources/js/features/backups/api/backups.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../../../lib/apiClient';
 import { deviceKeys } from '../../devices/api/getDevices';
-import type { BackupHistoryEntry, Device } from '../../../types';
+import type { BackupHistoryEntry, BackupScheduleConfig, BackupVersion, Device } from '../../../types';
 
 /**
  * Device config-backup hooks. History + latest-config read through the
@@ -60,6 +60,77 @@ export function useProvisionSshKey() {
     return useMutation({
         mutationFn: async (deviceId: number): Promise<{ message: string; ssh_enabled: boolean; ssh_enabled_by: boolean }> => {
             const { data } = await apiClient.post(`/devices/${deviceId}/provision-ssh-key`);
+            return data;
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: deviceKeys.all }),
+    });
+}
+
+/** Config version history for a device (git commits, newest first). */
+export function useDeviceVersions(deviceId: number | null) {
+    return useQuery({
+        queryKey: [...backupKeys.all, 'versions', deviceId ?? 0],
+        enabled: deviceId !== null,
+        queryFn: async (): Promise<BackupVersion[]> => {
+            const { data } = await apiClient.get<{ data: BackupVersion[] }>(`/devices/${deviceId}/backups/versions`);
+            return data.data;
+        },
+    });
+}
+
+/** Stored config text at a specific commit (for viewing an older version). */
+export function useDeviceConfigAt(deviceId: number | null, commit: string | null) {
+    return useQuery({
+        queryKey: [...backupKeys.all, 'config-at', deviceId ?? 0, commit ?? ''],
+        enabled: deviceId !== null && commit !== null,
+        queryFn: async (): Promise<string | null> => {
+            const { data } = await apiClient.get<{ data: { config: string | null } }>(`/devices/${deviceId}/backups/config`, { params: { commit } });
+            return data.data.config;
+        },
+    });
+}
+
+/** Unified diff of a device's config. `from` alone shows what that backup changed. */
+export function useDeviceDiff(deviceId: number | null, from: string | null, to: string | null) {
+    return useQuery({
+        queryKey: [...backupKeys.all, 'diff', deviceId ?? 0, from ?? '', to ?? ''],
+        enabled: deviceId !== null && from !== null,
+        queryFn: async (): Promise<string | null> => {
+            const { data } = await apiClient.get<{ data: { diff: string | null } }>(`/devices/${deviceId}/backups/diff`, { params: { from, to: to ?? '' } });
+            return data.data.diff;
+        },
+    });
+}
+
+/** The automatic-backup schedule. */
+export function useBackupSchedule() {
+    return useQuery({
+        queryKey: ['backup-schedule'],
+        queryFn: async (): Promise<BackupScheduleConfig> => {
+            const { data } = await apiClient.get<{ data: BackupScheduleConfig }>('/settings/backup-schedule');
+            return data.data;
+        },
+    });
+}
+
+/** Save the automatic-backup schedule. */
+export function useUpdateBackupSchedule() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (input: Omit<BackupScheduleConfig, 'last_run_at'>): Promise<BackupScheduleConfig> => {
+            const { data } = await apiClient.put<{ data: BackupScheduleConfig }>('/settings/backup-schedule', input);
+            return data.data;
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: ['backup-schedule'] }),
+    });
+}
+
+/** Queue a backup now for every backup-enabled device. */
+export function useRunAllBackups() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (): Promise<{ queued: number }> => {
+            const { data } = await apiClient.post<{ queued: number }>('/backups/run-all');
             return data;
         },
         onSuccess: () => qc.invalidateQueries({ queryKey: deviceKeys.all }),

--- a/resources/js/features/backups/api/backups.ts
+++ b/resources/js/features/backups/api/backups.ts
@@ -51,6 +51,21 @@ export function useUpdateBackupConfig() {
     });
 }
 
+/**
+ * Bootstrap key-based SSH on a MikroTik over its API (RouterOS can't export over the API).
+ * Rusted installs a generated key; My Mate stores it and switches the device to SSH backups.
+ */
+export function useProvisionSshKey() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (deviceId: number): Promise<{ message: string; ssh_enabled: boolean; ssh_enabled_by: boolean }> => {
+            const { data } = await apiClient.post(`/devices/${deviceId}/provision-ssh-key`);
+            return data;
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: deviceKeys.all }),
+    });
+}
+
 /** Queue a backup now. The device is marked `pending`; invalidate so the spinner shows. */
 export function useRunBackup() {
     const qc = useQueryClient();

--- a/resources/js/features/backups/components/BackupSection.tsx
+++ b/resources/js/features/backups/components/BackupSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ArrowClockwise, CircleNotch, Eye, FloppyDisk, X } from '@phosphor-icons/react';
-import { useDeviceBackups, useDeviceLatestConfig, useRunBackup, useUpdateBackupConfig } from '../api/backups';
+import { useDeviceBackups, useDeviceLatestConfig, useProvisionSshKey, useRunBackup, useUpdateBackupConfig } from '../api/backups';
 import { pushToast } from '../../../lib/toast';
 import { relativeTime } from '../../../lib/relativeTime';
 import { RUSTED_DRIVERS, type BackupStatus, type Device } from '../../../types';
@@ -65,7 +65,22 @@ export function BackupSection({ device, isAdmin }: { device: Device; isAdmin: bo
     const { data: history } = useDeviceBackups(device.id);
     const updateConfig = useUpdateBackupConfig();
     const runBackup = useRunBackup();
+    const provision = useProvisionSshKey();
     const [viewing, setViewing] = useState(false);
+
+    // MikroTik can't export config over the API, so offer to bootstrap key-based SSH over
+    // the API (installs a generated key on the device) when the device has no SSH cred yet.
+    const canProvision = device.poll_method === 'routeros' && device.ssh_credential_id === null;
+
+    function provisionKey() {
+        provision.mutate(device.id, {
+            onSuccess: (r) => pushToast({ title: 'Key-based SSH ready', detail: r.message, tone: 'up' }),
+            onError: (e: unknown) => {
+                const msg = (e as { response?: { data?: { message?: string } } })?.response?.data?.message;
+                pushToast({ title: 'Couldn\'t set up SSH key', detail: msg, tone: 'down' });
+            },
+        });
+    }
 
     const status = device.backup_status;
     const running = status === 'pending' || runBackup.isPending;
@@ -144,6 +159,23 @@ export function BackupSection({ device, isAdmin }: { device: Device; isAdmin: bo
                             <span className="truncate text-white/70">{suggested?.label ?? device.backup_driver ?? '-'}</span>
                         )}
                     </div>
+
+                    {/* MikroTik key-based-SSH bootstrap (RouterOS can't export over the API). */}
+                    {isAdmin && canProvision && (
+                        <button
+                            onClick={provisionKey}
+                            disabled={provision.isPending}
+                            title="Install an SSH key on this MikroTik over its API, then back it up over SSH"
+                            className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-500/10 px-2 py-1.5 text-xs font-medium text-emerald-300 ring-1 ring-emerald-400/25 transition hover:bg-emerald-500/20 disabled:opacity-40"
+                        >
+                            {provision.isPending ? <CircleNotch weight="bold" className="h-3.5 w-3.5 animate-spin" /> : null}
+                            {provision.isPending ? 'Setting up SSH key...' : 'Set up key-based SSH (over API)'}
+                        </button>
+                    )}
+                    {isAdmin && device.poll_method === 'routeros' && device.ssh_credential_id !== null && (
+                        <p className="text-[11px] text-emerald-300/70">Key-based SSH is set up for this device.</p>
+                    )}
+
                     {device.backup_at && (
                         <div className="flex items-center justify-between text-xs">
                             <span className="text-white/45">Last run</span>

--- a/resources/js/features/backups/components/BackupsView.tsx
+++ b/resources/js/features/backups/components/BackupsView.tsx
@@ -1,0 +1,264 @@
+import { useState } from 'react';
+import { Archive, ArrowClockwise, CircleNotch, Clock, GitCommit } from '@phosphor-icons/react';
+import { useDevices } from '../../devices/api/getDevices';
+import {
+    useBackupSchedule,
+    useUpdateBackupSchedule,
+    useRunAllBackups,
+    useDeviceVersions,
+    useDeviceDiff,
+    useDeviceConfigAt,
+} from '../api/backups';
+import { useIsAdmin } from '../../auth/api/auth';
+import { StatusDot } from '../../../components/StatusDot';
+import { relativeTime } from '../../../lib/relativeTime';
+import { pushToast } from '../../../lib/toast';
+import type { BackupFrequency, BackupScheduleConfig, Device } from '../../../types';
+
+const FREQS: { value: BackupFrequency; label: string }[] = [
+    { value: 'hourly', label: 'Every hour' },
+    { value: 'every_6h', label: 'Every 6 hours' },
+    { value: 'every_12h', label: 'Every 12 hours' },
+    { value: 'daily', label: 'Daily' },
+    { value: 'weekly', label: 'Weekly' },
+];
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const field = 'rounded-lg bg-white/[0.04] px-2 py-1 text-xs text-white/85 outline-none ring-1 ring-white/10 focus:ring-emerald-400/50';
+
+/** Colourised unified-diff renderer. */
+function DiffView({ text }: { text: string | null | undefined }) {
+    if (text === null || text === undefined) return <p className="p-4 text-xs text-white/35">Loading...</p>;
+    if (text.trim() === '') return <p className="p-4 text-xs text-white/40">No changes in this version.</p>;
+    return (
+        <pre className="overflow-auto p-3 font-mono text-[11px] leading-relaxed">
+            {text.split('\n').map((line, i) => {
+                let cls = 'text-white/55';
+                if (line.startsWith('+') && !line.startsWith('+++')) cls = 'bg-emerald-500/[0.07] text-emerald-300';
+                else if (line.startsWith('-') && !line.startsWith('---')) cls = 'bg-rose-500/[0.07] text-rose-300';
+                else if (line.startsWith('@@')) cls = 'text-sky-300';
+                else if (/^(diff |index |\+\+\+|---|new file|deleted)/.test(line)) cls = 'text-white/25';
+                return (
+                    <div key={i} className={cls}>
+                        {line || ' '}
+                    </div>
+                );
+            })}
+        </pre>
+    );
+}
+
+function ScheduleCard({ isAdmin }: { isAdmin: boolean }) {
+    const { data: schedule } = useBackupSchedule();
+    const update = useUpdateBackupSchedule();
+    const runAll = useRunAllBackups();
+
+    function save(patch: Partial<BackupScheduleConfig>) {
+        if (!schedule) return;
+        const { enabled, frequency, hour, weekday } = { ...schedule, ...patch };
+        update.mutate({ enabled, frequency, hour, weekday }, { onError: () => pushToast({ title: "Couldn't save schedule", tone: 'down' }) });
+    }
+
+    return (
+        <div className="rounded-2xl bg-white/[0.03] p-4 ring-1 ring-white/[0.06]">
+            <div className="mb-3 flex items-center justify-between">
+                <span className="flex items-center gap-2 text-sm font-semibold text-white/85">
+                    <Clock weight="light" className="h-4 w-4 text-white/50" /> Schedule
+                </span>
+                {isAdmin && (
+                    <button
+                        type="button"
+                        role="switch"
+                        aria-checked={schedule?.enabled ?? false}
+                        onClick={() => save({ enabled: !schedule?.enabled })}
+                        className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${schedule?.enabled ? 'bg-emerald-500' : 'bg-white/15'}`}
+                    >
+                        <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${schedule?.enabled ? 'translate-x-4' : 'translate-x-0.5'}`} />
+                    </button>
+                )}
+            </div>
+
+            {schedule ? (
+                <div className="space-y-2.5 text-xs text-white/60">
+                    <div className="flex items-center justify-between gap-2">
+                        <span>Frequency</span>
+                        <select className={field} value={schedule.frequency} disabled={!isAdmin} onChange={(e) => save({ frequency: e.target.value as BackupFrequency })}>
+                            {FREQS.map((f) => (
+                                <option key={f.value} value={f.value}>{f.label}</option>
+                            ))}
+                        </select>
+                    </div>
+                    {(schedule.frequency === 'daily' || schedule.frequency === 'weekly') && (
+                        <div className="flex items-center justify-between gap-2">
+                            <span>At hour</span>
+                            <select className={field} value={schedule.hour} disabled={!isAdmin} onChange={(e) => save({ hour: Number(e.target.value) })}>
+                                {Array.from({ length: 24 }, (_, h) => (
+                                    <option key={h} value={h}>{String(h).padStart(2, '0')}:00</option>
+                                ))}
+                            </select>
+                        </div>
+                    )}
+                    {schedule.frequency === 'weekly' && (
+                        <div className="flex items-center justify-between gap-2">
+                            <span>On</span>
+                            <select className={field} value={schedule.weekday} disabled={!isAdmin} onChange={(e) => save({ weekday: Number(e.target.value) })}>
+                                {WEEKDAYS.map((d, i) => (
+                                    <option key={i} value={i}>{d}</option>
+                                ))}
+                            </select>
+                        </div>
+                    )}
+                    {schedule.last_run_at && (
+                        <p className="text-[11px] text-white/35">Last scheduled run {relativeTime(schedule.last_run_at)}.</p>
+                    )}
+                    {isAdmin && (
+                        <button
+                            onClick={() => runAll.mutate(undefined, { onSuccess: (r) => pushToast({ title: `Queued ${r.queued} backup(s)`, tone: 'info' }), onError: () => pushToast({ title: "Couldn't start backups", tone: 'down' }) })}
+                            disabled={runAll.isPending}
+                            className="mt-1 flex w-full items-center justify-center gap-1.5 rounded-lg bg-white/[0.05] px-2 py-1.5 text-xs font-medium text-white/80 ring-1 ring-white/10 transition hover:bg-white/[0.09] disabled:opacity-40"
+                        >
+                            {runAll.isPending ? <CircleNotch weight="bold" className="h-3.5 w-3.5 animate-spin" /> : <ArrowClockwise weight="bold" className="h-3.5 w-3.5" />}
+                            Back up all now
+                        </button>
+                    )}
+                </div>
+            ) : (
+                <p className="text-xs text-white/35">Loading...</p>
+            )}
+        </div>
+    );
+}
+
+function VersionPanel({ device }: { device: Device }) {
+    const { data: versions, isLoading } = useDeviceVersions(device.id);
+    const [focus, setFocus] = useState<string | null>(null);
+    const [mode, setMode] = useState<'diff' | 'config'>('diff');
+    const commit = focus ?? versions?.[0]?.commit ?? null;
+
+    const diff = useDeviceDiff(device.id, mode === 'diff' ? commit : null, null);
+    const config = useDeviceConfigAt(device.id, mode === 'config' ? commit : null);
+
+    return (
+        <div className="flex min-h-0 flex-1 flex-col">
+            <div className="mb-3 flex items-center justify-between">
+                <div>
+                    <h2 className="text-base font-bold tracking-tight text-white">{device.name}</h2>
+                    <p className="text-xs text-white/40">{device.mgmt_ip} - backup history</p>
+                </div>
+                <div className="flex items-center gap-1 rounded-lg bg-white/[0.04] p-0.5 ring-1 ring-white/10">
+                    {(['diff', 'config'] as const).map((m) => (
+                        <button
+                            key={m}
+                            onClick={() => setMode(m)}
+                            className={`rounded-md px-2.5 py-1 text-xs font-medium transition ${mode === m ? 'bg-white/10 text-white' : 'text-white/50 hover:text-white/80'}`}
+                        >
+                            {m === 'diff' ? 'Changes' : 'Full config'}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            <div className="flex min-h-0 flex-1 gap-3">
+                {/* Version list. */}
+                <div className="w-56 shrink-0 space-y-1 overflow-auto">
+                    {isLoading ? (
+                        <p className="text-xs text-white/35">Loading...</p>
+                    ) : !versions || versions.length === 0 ? (
+                        <p className="rounded-xl bg-white/[0.02] px-3 py-2.5 text-xs text-white/40 ring-1 ring-white/[0.06]">No stored versions yet - run a backup.</p>
+                    ) : (
+                        versions.map((v) => (
+                            <button
+                                key={v.commit}
+                                onClick={() => setFocus(v.commit)}
+                                className={`w-full rounded-lg px-2.5 py-2 text-left ring-1 transition ${commit === v.commit ? 'bg-emerald-500/10 ring-emerald-400/25' : 'bg-white/[0.03] ring-white/[0.06] hover:bg-white/[0.05]'}`}
+                            >
+                                <div className="flex items-center gap-1.5 text-[11px] text-white/45">
+                                    <GitCommit weight="bold" className="h-3 w-3" />
+                                    <span className="font-mono">{v.commit}</span>
+                                    <span className="ml-auto">{v.date}</span>
+                                </div>
+                                <div className="mt-0.5 truncate text-[11px] text-white/60">{v.subject}</div>
+                            </button>
+                        ))
+                    )}
+                </div>
+
+                {/* Diff / config viewer. */}
+                <div className="min-w-0 flex-1 overflow-hidden rounded-xl bg-[#0b0b0f] ring-1 ring-white/10">
+                    {commit === null ? (
+                        <p className="p-4 text-xs text-white/35">No version selected.</p>
+                    ) : mode === 'diff' ? (
+                        <DiffView text={diff.data} />
+                    ) : config.data ? (
+                        <pre className="overflow-auto p-3 font-mono text-[11px] leading-relaxed text-white/75">{config.data}</pre>
+                    ) : (
+                        <p className="p-4 text-xs text-white/35">{config.isLoading ? 'Loading...' : 'No config at this version.'}</p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/** Full-page config-backup overview: schedule, backup-enabled devices, and git-backed
+ *  version history with diffs. */
+export function BackupsView() {
+    const isAdmin = useIsAdmin();
+    const { data: devices } = useDevices();
+    const [selectedId, setSelectedId] = useState<number | null>(null);
+
+    const backupDevices = (devices ?? []).filter((d) => d.backup_enabled);
+    const selected = backupDevices.find((d) => d.id === selectedId) ?? null;
+
+    return (
+        <div className="flex h-full min-h-0 w-full gap-4 p-6">
+            {/* Left: schedule + device list. */}
+            <div className="flex w-72 shrink-0 flex-col gap-4 overflow-y-auto">
+                <header className="flex items-center gap-2.5">
+                    <span className="grid h-9 w-9 place-items-center rounded-xl bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-400/20">
+                        <Archive weight="light" className="h-5 w-5" />
+                    </span>
+                    <div>
+                        <h1 className="text-base font-bold tracking-tight text-white">Backups</h1>
+                        <p className="text-[11px] text-white/40">{backupDevices.length} device(s)</p>
+                    </div>
+                </header>
+
+                <ScheduleCard isAdmin={isAdmin} />
+
+                <div className="space-y-1">
+                    {backupDevices.length === 0 ? (
+                        <p className="rounded-xl bg-white/[0.02] px-3 py-2.5 text-xs text-white/40 ring-1 ring-white/[0.06]">
+                            No devices have backups enabled. Enable them from a device's inspector.
+                        </p>
+                    ) : (
+                        backupDevices.map((d) => (
+                            <button
+                                key={d.id}
+                                onClick={() => setSelectedId(d.id)}
+                                className={`flex w-full items-center gap-2.5 rounded-xl px-3 py-2 text-left ring-1 transition ${selectedId === d.id ? 'bg-emerald-500/10 ring-emerald-400/25' : 'bg-white/[0.03] ring-white/[0.06] hover:bg-white/[0.05]'}`}
+                            >
+                                <StatusDot status={d.status} />
+                                <span className="min-w-0 flex-1">
+                                    <span className="block truncate text-sm font-medium text-white/85">{d.name}</span>
+                                    <span className="block truncate text-[11px] text-white/40">
+                                        {d.backup_at ? `backed up ${relativeTime(d.backup_at)}` : 'never backed up'}
+                                    </span>
+                                </span>
+                                {d.backup_status === 'failed' && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-rose-400" title="Last backup failed" />}
+                            </button>
+                        ))
+                    )}
+                </div>
+            </div>
+
+            {/* Right: version history + diff. */}
+            <div className="flex min-h-0 flex-1 flex-col rounded-2xl bg-white/[0.02] p-4 ring-1 ring-white/[0.06]">
+                {selected ? (
+                    <VersionPanel key={selected.id} device={selected} />
+                ) : (
+                    <div className="grid flex-1 place-items-center text-sm text-white/35">Pick a device to see its backup history and diffs.</div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/features/demo/components/DemoChrome.tsx
+++ b/resources/js/features/demo/components/DemoChrome.tsx
@@ -234,7 +234,7 @@ function Contact() {
                 </div>
                 <input className={field} placeholder="Company (optional)" value={form.company} onChange={set('company')} />
                 <textarea className={field} rows={4} placeholder="How can we help?" value={form.message} onChange={set('message')} required />
-                {contact.isError && <p className="text-xs text-rose-400/90">Sorry - that didn\'t send. Please try again.</p>}
+                {contact.isError && <p className="text-xs text-rose-400/90">Sorry - that didn't send. Please try again.</p>}
                 <button
                     type="submit"
                     disabled={!ready}

--- a/resources/js/features/devices/api/updateDevice.ts
+++ b/resources/js/features/devices/api/updateDevice.ts
@@ -12,6 +12,7 @@ type UpdateDeviceInput = {
     parent_device_id?: number | null;
     poll_method?: PollMethod;
     credential_id?: number | null;
+    ssh_credential_id?: number | null;
 };
 
 /** Patch a device (e.g. reclassify its type). Invalidates the device list so the map

--- a/resources/js/features/devices/api/updateDevice.ts
+++ b/resources/js/features/devices/api/updateDevice.ts
@@ -9,6 +9,7 @@ type UpdateDeviceInput = {
     name?: string;
     parent_device_id?: number | null;
     poll_method?: PollMethod;
+    credential_id?: number | null;
 };
 
 /** Patch a device (e.g. reclassify its type). Invalidates the device list so the map

--- a/resources/js/features/devices/api/updateDevice.ts
+++ b/resources/js/features/devices/api/updateDevice.ts
@@ -7,6 +7,8 @@ type UpdateDeviceInput = {
     id: number;
     device_type?: DeviceType;
     name?: string;
+    mgmt_ip?: string;
+    monitored?: boolean;
     parent_device_id?: number | null;
     poll_method?: PollMethod;
     credential_id?: number | null;

--- a/resources/js/features/devices/api/upgradeDevices.ts
+++ b/resources/js/features/devices/api/upgradeDevices.ts
@@ -9,14 +9,16 @@ import { apiClient } from '../../../lib/apiClient';
 export interface UpgradeDevicesInput {
     deviceIds: number[];
     ordered?: boolean; // upgrade downstream-first, waiting for each to recover
+    explicitOrder?: boolean; // keep deviceIds order as-is (operator re-ordered by hand)
 }
 
 export function useUpgradeDevices() {
     return useMutation({
-        mutationFn: async ({ deviceIds, ordered }: UpgradeDevicesInput): Promise<{ queued: number; ordered: boolean }> => {
+        mutationFn: async ({ deviceIds, ordered, explicitOrder }: UpgradeDevicesInput): Promise<{ queued: number; ordered: boolean }> => {
             const { data } = await apiClient.post<{ queued: number; ordered: boolean }>('/devices/upgrade', {
                 device_ids: deviceIds,
                 ordered: ordered ?? false,
+                explicit_order: explicitOrder ?? false,
             });
             return data;
         },
@@ -30,6 +32,13 @@ export interface UpgradePlanRow {
     name: string;
     action: 'upgrade' | 'skip';
     reason: string | null;
+    // Topology context so the operator can eyeball the order (furthest-out first).
+    status: 'up' | 'down' | 'unknown';
+    depth: number; // hops to the root - higher = further downstream
+    os_version: string | null;
+    latest_version: string | null;
+    parent_name: string | null;
+    neighbours: string[]; // linked peer device names
 }
 export interface UpgradePlan {
     order: number[];
@@ -39,8 +48,13 @@ export interface UpgradePlan {
 
 export function useUpgradePreflight() {
     return useMutation({
-        mutationFn: async (deviceIds: number[]): Promise<UpgradePlan> => {
-            const { data } = await apiClient.post<UpgradePlan>('/devices/upgrade/preflight', { device_ids: deviceIds });
+        // preserveOrder true = preview in the given order (after a manual re-order) instead
+        // of re-sorting furthest-first.
+        mutationFn: async ({ deviceIds, preserveOrder }: { deviceIds: number[]; preserveOrder?: boolean }): Promise<UpgradePlan> => {
+            const { data } = await apiClient.post<UpgradePlan>('/devices/upgrade/preflight', {
+                device_ids: deviceIds,
+                preserve_order: preserveOrder ?? false,
+            });
             return data;
         },
     });

--- a/resources/js/features/devices/components/DeviceEditModal.tsx
+++ b/resources/js/features/devices/components/DeviceEditModal.tsx
@@ -34,11 +34,13 @@ export function DeviceEditModal({ device, onClose }: { device: Device; onClose: 
     const [pollMethod, setPollMethod] = useState<PollMethod>(device.poll_method);
     const [deviceType, setDeviceType] = useState<DeviceType>(device.device_type);
     const [credentialId, setCredentialId] = useState<string>(device.credential_id != null ? String(device.credential_id) : '');
+    const [sshCredentialId, setSshCredentialId] = useState<string>(device.ssh_credential_id != null ? String(device.ssh_credential_id) : '');
     const [parentId, setParentId] = useState<string>(device.parent_device_id != null ? String(device.parent_device_id) : '');
     const [monitored, setMonitored] = useState<boolean>(device.monitored);
 
     const needsCredential = pollMethod !== 'none';
     const matchingCreds = (credentials ?? []).filter((c) => c.type === pollMethod);
+    const sshCreds = (credentials ?? []).filter((c) => c.type === 'ssh');
     const parentOptions = (devices ?? []).filter((d) => d.id !== device.id); // a device can't be its own parent
 
     function changePollMethod(m: PollMethod) {
@@ -61,6 +63,7 @@ export function DeviceEditModal({ device, onClose }: { device: Device; onClose: 
                 device_type: deviceType,
                 monitored,
                 credential_id: needsCredential && credentialId !== '' ? Number(credentialId) : null,
+                ssh_credential_id: sshCredentialId === '' ? null : Number(sshCredentialId),
                 parent_device_id: parentId === '' ? null : Number(parentId),
             },
             {
@@ -133,6 +136,21 @@ export function DeviceEditModal({ device, onClose }: { device: Device; onClose: 
                                     <option key={t.value} value={t.value}>{t.label}</option>
                                 ))}
                             </select>
+                        </label>
+
+                        {/* Dedicated SSH credential for config backups (separate from the poll cred). */}
+                        <label className="space-y-1 block">
+                            <span className={label}>SSH credential (for backups)</span>
+                            {sshCreds.length > 0 ? (
+                                <select value={sshCredentialId} onChange={(e) => setSshCredentialId(e.target.value)} className={field}>
+                                    <option value="">None - fall back to the poll credential</option>
+                                    {sshCreds.map((c) => (
+                                        <option key={c.id} value={c.id}>{c.name}</option>
+                                    ))}
+                                </select>
+                            ) : (
+                                <p className="px-1 text-xs text-white/40">No SSH credentials yet - add one (type "SSH") under Settings.</p>
+                            )}
                         </label>
 
                         <label className="space-y-1 block">

--- a/resources/js/features/devices/components/DeviceEditModal.tsx
+++ b/resources/js/features/devices/components/DeviceEditModal.tsx
@@ -1,0 +1,183 @@
+import { useState, type FormEvent } from 'react';
+import { createPortal } from 'react-dom';
+import { X, PencilSimple } from '@phosphor-icons/react';
+import { useUpdateDevice } from '../api/updateDevice';
+import { useCredentials } from '../../settings/api/credentials';
+import { useDevices } from '../api/getDevices';
+import { pushToast } from '../../../lib/toast';
+import type { Device, DeviceType, PollMethod } from '../../../types';
+
+const DEVICE_TYPES: { value: DeviceType; label: string }[] = [
+    { value: 'unknown', label: 'Auto-detect type' },
+    { value: 'router', label: 'Router' },
+    { value: 'switch', label: 'Switch' },
+    { value: 'ap', label: 'Access point' },
+    { value: 'server', label: 'Server' },
+    { value: 'internet', label: 'Internet / upstream' },
+];
+
+const field =
+    'w-full rounded-xl bg-white/[0.03] px-3 py-2 text-sm text-white ring-1 ring-white/10 outline-none ' +
+    'transition duration-300 placeholder:text-white/30 focus:bg-white/[0.05] focus:ring-2 focus:ring-emerald-400/60';
+
+const label = 'block text-[11px] font-medium uppercase tracking-wide text-white/40';
+
+/** Full device edit form in a modal - every field in one place, incl. the monitored
+ *  (enable/disable) toggle that pauses/resumes throughput + metrics polling. */
+export function DeviceEditModal({ device, onClose }: { device: Device; onClose: () => void }) {
+    const update = useUpdateDevice();
+    const { data: credentials } = useCredentials();
+    const { data: devices } = useDevices();
+
+    const [name, setName] = useState(device.name);
+    const [mgmtIp, setMgmtIp] = useState(device.mgmt_ip);
+    const [pollMethod, setPollMethod] = useState<PollMethod>(device.poll_method);
+    const [deviceType, setDeviceType] = useState<DeviceType>(device.device_type);
+    const [credentialId, setCredentialId] = useState<string>(device.credential_id != null ? String(device.credential_id) : '');
+    const [parentId, setParentId] = useState<string>(device.parent_device_id != null ? String(device.parent_device_id) : '');
+    const [monitored, setMonitored] = useState<boolean>(device.monitored);
+
+    const needsCredential = pollMethod !== 'none';
+    const matchingCreds = (credentials ?? []).filter((c) => c.type === pollMethod);
+    const parentOptions = (devices ?? []).filter((d) => d.id !== device.id); // a device can't be its own parent
+
+    function changePollMethod(m: PollMethod) {
+        setPollMethod(m);
+        // Drop a credential of the old type so we never submit e.g. RouterOS creds on SNMP.
+        if (m === 'none' || (credentialId !== '' && !matchingCreds.some((c) => String(c.id) === credentialId))) {
+            setCredentialId('');
+        }
+    }
+
+    function submit(e: FormEvent) {
+        e.preventDefault();
+        if (!name.trim() || !mgmtIp.trim()) return;
+        update.mutate(
+            {
+                id: device.id,
+                name: name.trim(),
+                mgmt_ip: mgmtIp.trim(),
+                poll_method: pollMethod,
+                device_type: deviceType,
+                monitored,
+                credential_id: needsCredential && credentialId !== '' ? Number(credentialId) : null,
+                parent_device_id: parentId === '' ? null : Number(parentId),
+            },
+            {
+                onSuccess: () => { pushToast({ title: 'Device saved', tone: 'up' }); onClose(); },
+                onError: () => pushToast({ title: "Couldn't save the device", detail: 'Check the fields (a valid IP is required).', tone: 'down' }),
+            },
+        );
+    }
+
+    return createPortal(
+        <div className="fixed inset-0 z-50 grid place-items-center p-4">
+            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+            <div className="animate-rise relative w-full max-w-md rounded-[1.5rem] bg-white/[0.05] p-1 shadow-[0_30px_80px_-20px_rgba(0,0,0,0.9)] ring-1 ring-white/10">
+                <div className="max-h-[85vh] overflow-y-auto rounded-[calc(1.5rem-0.25rem)] bg-[#0d0d11] p-6 ring-1 ring-white/10">
+                    <header className="mb-5 flex items-start justify-between">
+                        <div className="flex items-center gap-3">
+                            <span className="grid h-9 w-9 place-items-center rounded-xl bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-400/20">
+                                <PencilSimple weight="light" className="h-5 w-5" />
+                            </span>
+                            <div>
+                                <h2 className="text-base font-bold tracking-tight text-white">Edit device</h2>
+                                <p className="text-xs text-white/40">{device.name}</p>
+                            </div>
+                        </div>
+                        <button onClick={onClose} className="rounded-lg p-1 text-white/40 transition-colors hover:bg-white/5 hover:text-white/80">
+                            <X weight="bold" className="h-4 w-4" />
+                        </button>
+                    </header>
+
+                    <form onSubmit={submit} className="space-y-3.5">
+                        <label className="space-y-1 block">
+                            <span className={label}>Name</span>
+                            <input value={name} onChange={(e) => setName(e.target.value)} className={field} placeholder="Name" />
+                        </label>
+                        <label className="space-y-1 block">
+                            <span className={label}>Management IP</span>
+                            <input value={mgmtIp} onChange={(e) => setMgmtIp(e.target.value)} className={field} placeholder="Management IP" />
+                        </label>
+                        <label className="space-y-1 block">
+                            <span className={label}>Poll method</span>
+                            <select value={pollMethod} onChange={(e) => changePollMethod(e.target.value as PollMethod)} className={field}>
+                                <option value="snmp">SNMP</option>
+                                <option value="routeros">RouterOS API</option>
+                                <option value="none">Ping only (no throughput)</option>
+                            </select>
+                        </label>
+
+                        {needsCredential && (
+                            <label className="space-y-1 block">
+                                <span className={label}>Credential</span>
+                                {matchingCreds.length > 0 ? (
+                                    <select value={credentialId} onChange={(e) => setCredentialId(e.target.value)} className={field}>
+                                        <option value="">None</option>
+                                        {matchingCreds.map((c) => (
+                                            <option key={c.id} value={c.id}>{c.name}</option>
+                                        ))}
+                                    </select>
+                                ) : (
+                                    <p className="px-1 text-xs text-amber-300/80">
+                                        No {pollMethod === 'snmp' ? 'SNMP' : 'RouterOS'} credential yet - add one under Settings.
+                                    </p>
+                                )}
+                            </label>
+                        )}
+
+                        <label className="space-y-1 block">
+                            <span className={label}>Type</span>
+                            <select value={deviceType} onChange={(e) => setDeviceType(e.target.value as DeviceType)} className={field}>
+                                {DEVICE_TYPES.map((t) => (
+                                    <option key={t.value} value={t.value}>{t.label}</option>
+                                ))}
+                            </select>
+                        </label>
+
+                        <label className="space-y-1 block">
+                            <span className={label}>Parent (upstream device)</span>
+                            <select value={parentId} onChange={(e) => setParentId(e.target.value)} className={field}>
+                                <option value="">None</option>
+                                {parentOptions.map((d) => (
+                                    <option key={d.id} value={d.id}>{d.name}</option>
+                                ))}
+                            </select>
+                        </label>
+
+                        {/* Enable/disable monitoring. */}
+                        <div className="flex items-center justify-between rounded-xl bg-white/[0.03] px-3 py-2.5 ring-1 ring-white/10">
+                            <span className="min-w-0">
+                                <span className="block text-sm font-medium text-white/85">Monitored</span>
+                                <span className="block text-[11px] text-white/40">{monitored ? 'Polling throughput + metrics' : 'Paused - not polled'}</span>
+                            </span>
+                            <button
+                                type="button"
+                                role="switch"
+                                aria-checked={monitored}
+                                onClick={() => setMonitored((m) => !m)}
+                                className={`relative h-6 w-11 shrink-0 rounded-full transition-colors ${monitored ? 'bg-emerald-500' : 'bg-white/15'}`}
+                            >
+                                <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${monitored ? 'translate-x-5' : 'translate-x-0.5'}`} />
+                            </button>
+                        </div>
+
+                        <div className="flex items-center justify-end gap-2.5 pt-1">
+                            <button type="button" onClick={onClose} className="rounded-full px-4 py-2 text-sm font-medium text-white/60 transition-colors hover:text-white/90">
+                                Cancel
+                            </button>
+                            <button
+                                type="submit"
+                                disabled={update.isPending || !name.trim() || !mgmtIp.trim()}
+                                className="rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-emerald-950 shadow-[0_8px_24px_-8px_rgba(16,185,129,0.6)] transition hover:bg-emerald-400 active:scale-[0.98] disabled:opacity-40"
+                            >
+                                {update.isPending ? 'Saving...' : 'Save'}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>,
+        document.body,
+    );
+}

--- a/resources/js/features/devices/components/DeviceForm.tsx
+++ b/resources/js/features/devices/components/DeviceForm.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from 'react';
 import { Plus } from '@phosphor-icons/react';
 import { useCreateDevice } from '../api/createDevice';
 import { useAgents } from '../../settings/api/agents';
+import { useCredentials } from '../../settings/api/credentials';
 import { useIsAdmin } from '../../auth/api/auth';
 import type { DeviceType, PollMethod } from '../../../types';
 
@@ -22,11 +23,25 @@ export function DeviceForm() {
     const isAdmin = useIsAdmin();
     const create = useCreateDevice();
     const { data: agents } = useAgents();
+    const { data: credentials } = useCredentials();
     const [name, setName] = useState('');
     const [mgmtIp, setMgmtIp] = useState('');
     const [pollMethod, setPollMethod] = useState<PollMethod>('snmp');
     const [deviceType, setDeviceType] = useState<DeviceType>('unknown');
     const [agentId, setAgentId] = useState<string>(''); // '' = polled centrally
+    const [credentialId, setCredentialId] = useState<string>(''); // '' = none picked yet
+
+    // Throughput polling needs a matching credential (SNMP community / RouterOS login).
+    // Ping-only devices don't poll, so there's nothing to authenticate with.
+    const needsCredential = pollMethod !== 'none';
+    const matchingCreds = (credentials ?? []).filter((c) => c.type === pollMethod);
+
+    // Switching poll method invalidates a credential of the old type - clear it so we
+    // never submit e.g. a RouterOS credential against an SNMP device.
+    function changePollMethod(m: PollMethod) {
+        setPollMethod(m);
+        setCredentialId('');
+    }
 
     function submit(e: FormEvent) {
         e.preventDefault();
@@ -35,8 +50,9 @@ export function DeviceForm() {
             {
                 name: name.trim(), mgmt_ip: mgmtIp.trim(), poll_method: pollMethod, device_type: deviceType,
                 agent_id: agentId === '' ? null : Number(agentId),
+                credential_id: needsCredential && credentialId !== '' ? Number(credentialId) : null,
             },
-            { onSuccess: () => { setName(''); setMgmtIp(''); setDeviceType('unknown'); setAgentId(''); } },
+            { onSuccess: () => { setName(''); setMgmtIp(''); setDeviceType('unknown'); setAgentId(''); setCredentialId(''); } },
         );
     }
 
@@ -47,11 +63,31 @@ export function DeviceForm() {
         <form onSubmit={submit} className="space-y-2.5">
             <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" className={field} />
             <input value={mgmtIp} onChange={(e) => setMgmtIp(e.target.value)} placeholder="Management IP" className={field} />
-            <select value={pollMethod} onChange={(e) => setPollMethod(e.target.value as PollMethod)} className={field}>
+            <select value={pollMethod} onChange={(e) => changePollMethod(e.target.value as PollMethod)} className={field}>
                 <option value="snmp">SNMP</option>
                 <option value="routeros">RouterOS API</option>
                 <option value="none">Ping only (no throughput)</option>
             </select>
+
+            {/* Credential for the chosen poll method. Without one, interface discovery
+                fails ("no SNMP community"), so we surface it here rather than after the fact. */}
+            {needsCredential && (
+                matchingCreds.length > 0 ? (
+                    <select value={credentialId} onChange={(e) => setCredentialId(e.target.value)} className={field}>
+                        <option value="">Select a {pollMethod === 'snmp' ? 'SNMP' : 'RouterOS'} credential</option>
+                        {matchingCreds.map((c) => (
+                            <option key={c.id} value={c.id}>
+                                {c.name}
+                            </option>
+                        ))}
+                    </select>
+                ) : (
+                    <p className="px-1 text-xs text-amber-300/80">
+                        No {pollMethod === 'snmp' ? 'SNMP' : 'RouterOS'} credential yet - add one under Settings first, or discovery won't have anything to authenticate with.
+                    </p>
+                )
+            )}
+
             <select value={deviceType} onChange={(e) => setDeviceType(e.target.value as DeviceType)} className={field}>
                 {DEVICE_TYPES.map((t) => (
                     <option key={t.value} value={t.value}>

--- a/resources/js/features/devices/components/DevicesView.tsx
+++ b/resources/js/features/devices/components/DevicesView.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
-import { TrashSimple, ArrowRight, ListDashes, DownloadSimple } from '@phosphor-icons/react';
+import { TrashSimple, ArrowRight, ListDashes, DownloadSimple, PencilSimple, Pause, Play } from '@phosphor-icons/react';
 import { useDevices } from '../api/getDevices';
 import { useDeleteDevice } from '../api/deleteDevice';
+import { useUpdateDevice } from '../api/updateDevice';
 import { useUpgradeDevices, useUpgradePreflight, type UpgradePlanRow } from '../api/upgradeDevices';
 import { DeviceForm } from './DeviceForm';
+import { DeviceEditModal } from './DeviceEditModal';
 import { useIsAdmin } from '../../auth/api/auth';
 import { StatusDot } from '../../../components/StatusDot';
 import { DeviceTypeBadge } from '../../../components/DeviceTypeBadge';
@@ -20,6 +22,15 @@ export function DevicesView() {
     const isAdmin = useIsAdmin();
     const { data: devices, isLoading } = useDevices();
     const del = useDeleteDevice();
+    const update = useUpdateDevice();
+    const [editing, setEditing] = useState<Device | null>(null);
+
+    function toggleMonitored(d: Device) {
+        update.mutate(
+            { id: d.id, monitored: !d.monitored },
+            { onError: () => pushToast({ title: "Couldn't change monitoring", tone: 'down' }) },
+        );
+    }
     const upgrade = useUpgradeDevices();
     const preflight = useUpgradePreflight();
     const [selected, setSelected] = useState<Set<number>>(new Set());
@@ -195,7 +206,31 @@ export function DevicesView() {
                                                     'SNMP'
                                                 )}
                                             </span>
+                                            {/* Enable/disable monitoring inline - paused devices poll nothing. */}
+                                            {isAdmin && (
+                                                <button
+                                                    onClick={() => toggleMonitored(d)}
+                                                    title={d.monitored ? 'Monitoring on - click to pause' : 'Paused - click to resume'}
+                                                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ring-1 transition-colors ${
+                                                        d.monitored
+                                                            ? 'bg-emerald-500/10 text-emerald-300 ring-emerald-400/20 hover:bg-emerald-500/20'
+                                                            : 'bg-amber-500/10 text-amber-300 ring-amber-400/25 hover:bg-amber-500/20'
+                                                    }`}
+                                                >
+                                                    {d.monitored ? <Pause weight="bold" className="h-3 w-3" /> : <Play weight="bold" className="h-3 w-3" />}
+                                                    <span className="hidden sm:inline">{d.monitored ? 'Live' : 'Paused'}</span>
+                                                </button>
+                                            )}
                                             <div className="flex items-center gap-1">
+                                                {isAdmin && (
+                                                    <button
+                                                        onClick={() => setEditing(d)}
+                                                        title="Edit device"
+                                                        className="rounded-lg p-1 text-white/40 opacity-100 transition-all duration-300 ease-fluid hover:bg-white/5 hover:text-white/80 lg:text-white/30 lg:opacity-0 lg:group-hover:opacity-100"
+                                                    >
+                                                        <PencilSimple weight="bold" className="h-4 w-4" />
+                                                    </button>
+                                                )}
                                                 <button
                                                     onClick={() => open(d.id)}
                                                     title="Show on map"
@@ -275,6 +310,8 @@ export function DevicesView() {
                         onClose={() => setPendingUpgrade(null)}
                     />
                 ))}
+
+            {editing && <DeviceEditModal device={editing} onClose={() => setEditing(null)} />}
 
             {deleting && (
                 <ConfirmDialog

--- a/resources/js/features/devices/components/DevicesView.tsx
+++ b/resources/js/features/devices/components/DevicesView.tsx
@@ -47,7 +47,7 @@ export function DevicesView() {
         // Dependency pre-flight: show what will upgrade vs be skipped first.
         let plan;
         try {
-            plan = await preflight.mutateAsync(ids);
+            plan = await preflight.mutateAsync({ deviceIds: ids });
         } catch {
             pushToast({ title: 'Couldn\'t check upgrade dependencies', tone: 'down' });
             return;

--- a/resources/js/features/devices/components/DevicesView.tsx
+++ b/resources/js/features/devices/components/DevicesView.tsx
@@ -183,7 +183,16 @@ export function DevicesView() {
                                             <DeviceTypeBadge type={d.device_type} className="h-6 w-7 shrink-0" />
                                             <span className="min-w-0 flex-1">
                                                 <span className="block truncate text-sm font-medium text-white/85">{d.name}</span>
-                                                <span className="block truncate text-xs text-white/35">{d.mgmt_ip}</span>
+                                                <span className="flex items-center gap-2 truncate text-xs text-white/35">
+                                                    <span className="shrink-0">{d.mgmt_ip}</span>
+                                                    {(d.cpu_pct != null || d.mem_used_pct != null || d.temp_c != null) && (
+                                                        <span className="hidden items-center gap-2 truncate font-mono text-[10px] text-white/30 sm:inline-flex">
+                                                            {d.cpu_pct != null && <span>cpu {Math.round(d.cpu_pct)}%</span>}
+                                                            {d.mem_used_pct != null && <span>mem {Math.round(d.mem_used_pct)}%</span>}
+                                                            {d.temp_c != null && <span>{Math.round(d.temp_c)}&deg;</span>}
+                                                        </span>
+                                                    )}
+                                                </span>
                                             </span>
                                         </button>
                                         <div className="flex shrink-0 items-center gap-2.5">

--- a/resources/js/features/devices/components/DevicesView.tsx
+++ b/resources/js/features/devices/components/DevicesView.tsx
@@ -283,7 +283,7 @@ export function DevicesView() {
                     message={
                         <>
                             Delete <span className="font-semibold text-white/85">{deleting.name}</span>? It will stop being monitored and be removed
-                            from every map. This can\'t be undone.
+                            from every map. This can't be undone.
                         </>
                     }
                     confirmLabel="Delete"

--- a/resources/js/features/discovery/components/CandidateReview.tsx
+++ b/resources/js/features/discovery/components/CandidateReview.tsx
@@ -61,7 +61,7 @@ export function CandidateReview({ open, scanning }: { open: boolean; scanning?: 
             {scanning && (
                 <div className="flex items-center gap-2 rounded-xl bg-emerald-500/10 px-3 py-2 text-xs text-emerald-200 ring-1 ring-emerald-400/20">
                     <CircleNotch weight="bold" className="h-3.5 w-3.5 animate-spin" />
-                    Scanning subnets - new devices appear here as they\'re found.
+                    Scanning subnets - new devices appear here as they're found.
                 </div>
             )}
 

--- a/resources/js/features/discovery/components/SubnetManager.tsx
+++ b/resources/js/features/discovery/components/SubnetManager.tsx
@@ -111,7 +111,7 @@ export function SubnetManager({
                         ))}
                     </select>
                 )}
-                {create.isError && <p className="px-1 text-xs text-rose-400/90">Couldn\'t add - enter a valid IPv4 CIDR (and not a duplicate).</p>}
+                {create.isError && <p className="px-1 text-xs text-rose-400/90">Couldn't add - enter a valid IPv4 CIDR (and not a duplicate).</p>}
             </form>
             )}
 

--- a/resources/js/features/settings/api/credentials.ts
+++ b/resources/js/features/settings/api/credentials.ts
@@ -17,7 +17,7 @@ export function useCredentials() {
 export interface CredentialInput {
     id?: number;
     name: string;
-    type: 'snmp' | 'routeros';
+    type: 'snmp' | 'routeros' | 'ssh';
     snmp_community?: string;
     username?: string;
     password?: string;

--- a/resources/js/features/settings/components/SettingsView.tsx
+++ b/resources/js/features/settings/components/SettingsView.tsx
@@ -304,9 +304,10 @@ function CredentialForm({ initial, onDone }: { initial?: Credential; onDone: () 
     return (
         <div className="space-y-2.5 rounded-xl bg-white/[0.03] p-3 ring-1 ring-white/10">
             <input className={field} placeholder="Name" value={form.name} onChange={(e) => set('name', e.target.value)} />
-            <select className={field} value={form.type} onChange={(e) => set('type', e.target.value as 'snmp' | 'routeros')}>
+            <select className={field} value={form.type} onChange={(e) => set('type', e.target.value as 'snmp' | 'routeros' | 'ssh')}>
                 <option value="snmp">SNMP</option>
                 <option value="routeros">RouterOS API</option>
+                <option value="ssh">SSH (for backups)</option>
             </select>
             {form.type === 'snmp' ? (
                 <input
@@ -490,7 +491,7 @@ function CredentialsSection() {
                             <Key weight="light" className="h-4 w-4 shrink-0 text-white/40" />
                             <span className="min-w-0 flex-1 truncate text-sm text-white/85">
                                 {c.name}
-                                <span className="text-white/35"> - {c.type === 'snmp' ? 'SNMP' : 'RouterOS'}</span>
+                                <span className="text-white/35"> - {c.type === 'snmp' ? 'SNMP' : c.type === 'ssh' ? 'SSH' : 'RouterOS'}</span>
                                 {c.device_count > 0 && <span className="text-white/30"> - {c.device_count} device(s)</span>}
                             </span>
                             {!c.has_secret && <span className="text-[10px] text-amber-300/80">no secret</span>}

--- a/resources/js/features/shell/AppShell.tsx
+++ b/resources/js/features/shell/AppShell.tsx
@@ -13,6 +13,7 @@ import { OutagesView } from '../outages/components/OutagesView';
 import { useOutages } from '../outages/api/getOutages';
 import { SettingsView } from '../settings/components/SettingsView';
 import { AlertsView } from '../alerts/components/AlertsView';
+import { UpgradesView } from '../upgrades/components/UpgradesView';
 import { ImportView } from '../import/components/ImportView';
 
 /**
@@ -65,6 +66,7 @@ export function AppShell() {
             {view === 'discovery' && <DiscoveryView />}
             {view === 'outages' && <OutagesView />}
             {view === 'alerts' && <AlertsView />}
+            {view === 'upgrades' && <UpgradesView />}
             {view === 'settings' && <SettingsView />}
             {view === 'import' && <ImportView />}
         </main>

--- a/resources/js/features/shell/AppShell.tsx
+++ b/resources/js/features/shell/AppShell.tsx
@@ -14,6 +14,7 @@ import { useOutages } from '../outages/api/getOutages';
 import { SettingsView } from '../settings/components/SettingsView';
 import { AlertsView } from '../alerts/components/AlertsView';
 import { UpgradesView } from '../upgrades/components/UpgradesView';
+import { BackupsView } from '../backups/components/BackupsView';
 import { ImportView } from '../import/components/ImportView';
 
 /**
@@ -67,6 +68,7 @@ export function AppShell() {
             {view === 'outages' && <OutagesView />}
             {view === 'alerts' && <AlertsView />}
             {view === 'upgrades' && <UpgradesView />}
+            {view === 'backups' && <BackupsView />}
             {view === 'settings' && <SettingsView />}
             {view === 'import' && <ImportView />}
         </main>

--- a/resources/js/features/shell/NavRail.tsx
+++ b/resources/js/features/shell/NavRail.tsx
@@ -1,4 +1,4 @@
-import { MapTrifold, SquaresFour, ListDashes, MagnifyingGlass, Warning, Bell, ArrowCircleUp, GearSix, DownloadSimple, X, type Icon } from '@phosphor-icons/react';
+import { MapTrifold, SquaresFour, ListDashes, MagnifyingGlass, Warning, Bell, ArrowCircleUp, Archive, GearSix, DownloadSimple, X, type Icon } from '@phosphor-icons/react';
 import { useView, setView, useNavOpen, setNavOpen, type View } from '../../lib/shellStore';
 import { MapLegend } from './MapLegend';
 
@@ -10,6 +10,7 @@ const ITEMS: { id: View; label: string; icon: Icon }[] = [
     { id: 'outages', label: 'Outages', icon: Warning },
     { id: 'alerts', label: 'Alerts', icon: Bell },
     { id: 'upgrades', label: 'Upgrades', icon: ArrowCircleUp },
+    { id: 'backups', label: 'Backups', icon: Archive },
     { id: 'import', label: 'Import', icon: DownloadSimple },
     { id: 'settings', label: 'Settings', icon: GearSix },
 ];

--- a/resources/js/features/shell/NavRail.tsx
+++ b/resources/js/features/shell/NavRail.tsx
@@ -1,4 +1,4 @@
-import { MapTrifold, SquaresFour, ListDashes, MagnifyingGlass, Warning, Bell, GearSix, DownloadSimple, X, type Icon } from '@phosphor-icons/react';
+import { MapTrifold, SquaresFour, ListDashes, MagnifyingGlass, Warning, Bell, ArrowCircleUp, GearSix, DownloadSimple, X, type Icon } from '@phosphor-icons/react';
 import { useView, setView, useNavOpen, setNavOpen, type View } from '../../lib/shellStore';
 import { MapLegend } from './MapLegend';
 
@@ -9,6 +9,7 @@ const ITEMS: { id: View; label: string; icon: Icon }[] = [
     { id: 'discovery', label: 'Discovery', icon: MagnifyingGlass },
     { id: 'outages', label: 'Outages', icon: Warning },
     { id: 'alerts', label: 'Alerts', icon: Bell },
+    { id: 'upgrades', label: 'Upgrades', icon: ArrowCircleUp },
     { id: 'import', label: 'Import', icon: DownloadSimple },
     { id: 'settings', label: 'Settings', icon: GearSix },
 ];

--- a/resources/js/features/topology/api/createLink.ts
+++ b/resources/js/features/topology/api/createLink.ts
@@ -5,9 +5,9 @@ import { linkKeys } from './getLinks';
 
 export interface CreateLinkInput {
     a_device_id: number;
-    a_interface_id: number;
+    a_interface_id: number | null; // null = ping-only end (no interface)
     b_device_id: number;
-    b_interface_id: number;
+    b_interface_id: number | null;
 }
 
 export function useCreateLink() {

--- a/resources/js/features/topology/api/getDeviceMetricSamples.ts
+++ b/resources/js/features/topology/api/getDeviceMetricSamples.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../../../lib/apiClient';
+import type { DeviceMetricSample } from '../../../types';
+
+// Query keys for a device's cpu/mem/temp history series.
+export const metricSampleKeys = {
+    all: ['device-metric-samples'] as const,
+    series: (id: number, windowSec: number) => [...metricSampleKeys.all, id, windowSec] as const,
+};
+
+const stamp = (d: Date) => d.toISOString().slice(0, 19);
+
+async function fetchDeviceMetricSamples(id: number, windowSec: number): Promise<DeviceMetricSample[]> {
+    const to = new Date();
+    const from = new Date(to.getTime() - windowSec * 1000);
+    const { data } = await apiClient.get<{ data: DeviceMetricSample[] }>(`/devices/${id}/metric-samples`, {
+        params: { from: stamp(from), to: stamp(to) },
+    });
+    return data.data;
+}
+
+/** cpu/mem/temp history for one device over the trailing `windowSec`. Polls while shown. */
+export function useDeviceMetricSamples(id: number | null, windowSec: number, enabled = true) {
+    return useQuery({
+        queryKey: metricSampleKeys.series(id ?? 0, windowSec),
+        queryFn: () => fetchDeviceMetricSamples(id as number, windowSec),
+        enabled: enabled && id !== null,
+        refetchInterval: enabled ? 30_000 : false,
+    });
+}

--- a/resources/js/features/topology/api/updateLink.ts
+++ b/resources/js/features/topology/api/updateLink.ts
@@ -6,9 +6,9 @@ import { linkKeys } from './getLinks';
 export interface UpdateLinkInput {
     id: number;
     a_device_id: number;
-    a_interface_id: number;
+    a_interface_id: number | null; // null = ping-only end (no interface)
     b_device_id: number;
-    b_interface_id: number;
+    b_interface_id: number | null;
     // Per-link bandwidth override A->B / B->A; null reverts to the derived speed.
     bw_ab_mbps?: number | null;
     bw_ba_mbps?: number | null;

--- a/resources/js/features/topology/components/DeviceInspector.tsx
+++ b/resources/js/features/topology/components/DeviceInspector.tsx
@@ -17,12 +17,14 @@ import { useDeviceInterfaces } from '../api/getDeviceInterfaces';
 import { useDiscoverDevice } from '../api/discoverDevice';
 import { useUpdateDevice } from '../../devices/api/updateDevice';
 import { useUpgradeDevices } from '../../devices/api/upgradeDevices';
+import { useCredentials } from '../../settings/api/credentials';
 import { useLinks } from '../api/getLinks';
 import { useDeleteLink } from '../api/deleteLink';
 import { useMap, useAddDeviceToMap, useRemoveDeviceFromMap } from '../../maps/api/maps';
 import { LinkHistoryDialog } from './LinkHistoryDialog';
 import { ChartModal } from './ChartModal';
 import { BackupSection } from '../../backups/components/BackupSection';
+import { DeviceResources } from './DeviceResources';
 import { ConfirmDialog } from '../../../components/Dialog';
 import { pushToast } from '../../../lib/toast';
 import { useDeviceSamples } from '../api/getDeviceSamples';
@@ -120,6 +122,38 @@ function PollMethodPicker({ device }: { device: Device }) {
             >
                 {POLL_METHOD_OPTIONS.map((o) => (
                     <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+            </select>
+        </div>
+    );
+}
+
+// Editable "Credential" cell: assign the SNMP community / RouterOS login the poller
+// authenticates with. Hidden for ping-only devices (nothing to authenticate). Without a
+// credential, interface discovery fails with "no SNMP community", so this is the fix.
+function CredentialPicker({ device }: { device: Device }) {
+    const update = useUpdateDevice();
+    const { data: credentials } = useCredentials();
+    const matching = (credentials ?? []).filter((c) => c.type === device.poll_method);
+
+    return (
+        <div className="min-w-0">
+            <p className="text-[10px] font-medium uppercase tracking-[0.16em] text-white/30">Credential</p>
+            <select
+                value={device.credential_id ?? ''}
+                onChange={(e) => {
+                    const value = e.target.value === '' ? null : Number(e.target.value);
+                    if (value === device.credential_id) return;
+                    update.mutate(
+                        { id: device.id, credential_id: value },
+                        { onError: () => pushToast({ title: 'Couldn\'t change credential', tone: 'down' }) },
+                    );
+                }}
+                className="-ml-1 mt-0.5 w-full truncate rounded-md bg-white/[0.03] px-1 py-0.5 text-sm text-white/85 outline-none ring-1 ring-white/10 transition hover:ring-white/25 focus:ring-emerald-400/50"
+            >
+                <option value="">{matching.length > 0 ? 'None' : 'None - add one in Settings'}</option>
+                {matching.map((c) => (
+                    <option key={c.id} value={c.id}>{c.name}</option>
                 ))}
             </select>
         </div>
@@ -603,6 +637,7 @@ export function DeviceInspector() {
                 ) : (
                     <Detail label="Poll method" value={pollLabel[device.poll_method] ?? device.poll_method} />
                 )}
+                {isAdmin && !pingOnly && <CredentialPicker device={device} />}
                 <Detail label="Parent" value={device.parent_name ?? '-'} />
             </div>
 
@@ -626,6 +661,12 @@ export function DeviceInspector() {
                     />
                 </div>
             </Section>
+            )}
+
+            {!pingOnly && (
+                <Section title="Resources">
+                    <DeviceResources device={device} />
+                </Section>
             )}
 
             {pingOnly ? (
@@ -670,9 +711,9 @@ export function DeviceInspector() {
                             return (
                                 <div key={l.id} className="flex items-center gap-1.5 text-xs">
                                     <span className="min-w-0 flex-1 truncate text-white/80">
-                                        {localIf.name}
+                                        {localIf?.name ?? '(no interface)'}
                                         <span className="text-white/35"> → {peerNm}</span>
-                                        <span className="text-white/30"> - {peerIf.name}</span>
+                                        {peerIf && <span className="text-white/30"> - {peerIf.name}</span>}
                                     </span>
                                     {isAdmin && (
                                         <>
@@ -684,7 +725,7 @@ export function DeviceInspector() {
                                                 <PencilSimple weight="bold" className="h-3.5 w-3.5" />
                                             </button>
                                             <button
-                                                onClick={() => setDeletingLink({ id: l.id, label: `${localIf.name} -> ${peerNm}` })}
+                                                onClick={() => setDeletingLink({ id: l.id, label: `${localIf?.name ?? '(no interface)'} -> ${peerNm}` })}
                                                 title="Delete link"
                                                 className="rounded-md p-1 text-white/40 transition-colors hover:bg-rose-500/10 hover:text-rose-300"
                                             >

--- a/resources/js/features/topology/components/DeviceResources.tsx
+++ b/resources/js/features/topology/components/DeviceResources.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from 'react';
+import type { Device, DeviceMetricSample } from '../../../types';
+import { useDeviceMetricSamples } from '../api/getDeviceMetricSamples';
+
+// One resource row: label, sparkline of its recent history, and the current value.
+// Each metric auto-scales its own sparkline (cpu/mem are %, temp is C - no shared axis).
+type Row = {
+    key: 'cpu' | 'mem' | 'temp';
+    label: string;
+    color: string;
+    current: number | null;
+    field: keyof DeviceMetricSample;
+    format: (v: number) => string;
+};
+
+function Sparkline({ values, color }: { values: number[]; color: string }) {
+    const path = useMemo(() => {
+        if (values.length < 2) return null;
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        const span = max - min || 1;
+        const w = 100;
+        const h = 24;
+        return values
+            .map((v, i) => {
+                const x = (i / (values.length - 1)) * w;
+                const y = h - ((v - min) / span) * h;
+                return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+            })
+            .join(' ');
+    }, [values]);
+
+    if (path === null) {
+        return <div className="h-6 flex-1 rounded bg-white/[0.03]" />;
+    }
+
+    return (
+        <svg viewBox="0 0 100 24" preserveAspectRatio="none" className="h-6 flex-1">
+            <path d={path} fill="none" stroke={color} strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+        </svg>
+    );
+}
+
+/**
+ * Device resource metrics (cpu/mem/temp): current value + a recent-history sparkline per
+ * metric. Renders nothing for a device that reports no metrics at all (ping-only, or gear
+ * that doesn't answer the OIDs) so the inspector stays uncluttered.
+ */
+export function DeviceResources({ device }: { device: Device }) {
+    const samples = useDeviceMetricSamples(device.id, 3600);
+    const data = samples.data ?? [];
+
+    const rows: Row[] = [
+        { key: 'cpu', label: 'CPU', color: '#34d399', current: device.cpu_pct, field: 'cpu_pct', format: (v) => `${v.toFixed(v < 10 ? 1 : 0)}%` },
+        { key: 'mem', label: 'Memory', color: '#38bdf8', current: device.mem_used_pct, field: 'mem_used_pct', format: (v) => `${v.toFixed(v < 10 ? 1 : 0)}%` },
+        { key: 'temp', label: 'Temp', color: '#fbbf24', current: device.temp_c, field: 'temp_c', format: (v) => `${Math.round(v)}°C` },
+    ];
+
+    return (
+        <div className="space-y-2">
+            {rows.map((r) => {
+                const series = data.map((s) => s[r.field] as number | null).filter((v): v is number => v !== null);
+                return (
+                    <div key={r.key} className="flex items-center gap-2.5">
+                        <span className="w-14 shrink-0 text-[11px] font-medium text-white/50">{r.label}</span>
+                        <Sparkline values={series} color={r.color} />
+                        <span className="w-12 shrink-0 text-right text-xs tabular-nums text-white/80">
+                            {r.current === null ? '-' : r.format(r.current)}
+                        </span>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/resources/js/features/topology/components/LinkBinderDialog.tsx
+++ b/resources/js/features/topology/components/LinkBinderDialog.tsx
@@ -37,7 +37,9 @@ export function EndPicker({
     const ifs = useDeviceInterfaces(device?.id ?? null);
     const discover = useDiscoverDevice();
     const [open, setOpen] = useState(false);
-    const empty = !ifs.isLoading && (ifs.data?.length ?? 0) === 0;
+    // Ping-only devices have no interfaces by design - the link binds to the device only.
+    const pingOnly = device?.poll_method === 'none';
+    const empty = !pingOnly && !ifs.isLoading && (ifs.data?.length ?? 0) === 0;
     const selected = ifs.data?.find((i) => String(i.id) === value);
 
     const buttonText = selected ? ifaceLabel(selected) : ifs.isLoading ? 'Loading interfaces...' : 'Select interface';
@@ -49,8 +51,12 @@ export function EndPicker({
                 <span className="truncate text-white/35">{device?.mgmt_ip}</span>
             </span>
 
-            {/* Empty -> offer on-demand discovery + show why it\'s empty. */}
-            {empty ? (
+            {/* Ping-only -> no interface to pick; the link binds to the device itself. */}
+            {pingOnly ? (
+                <div className={`${field} flex items-center gap-2 text-white/45`}>
+                    Ping-only device - linked without an interface
+                </div>
+            ) : empty ? (
                 <div className="space-y-1.5">
                     <button
                         type="button"
@@ -143,20 +149,23 @@ export function LinkBinderDialog({
     const create = useCreateLink();
     const busy = create.isPending;
     const isError = create.isError;
-    const ready = aIf !== '' && bIf !== '' && !busy;
+    // A ping-only end contributes no interface, so it's ready without a selection.
+    const aPingOnly = aDev?.poll_method === 'none';
+    const bPingOnly = bDev?.poll_method === 'none';
+    const ready = (aPingOnly || aIf !== '') && (bPingOnly || bIf !== '') && !busy;
 
     // Read-only viewers can\'t create links (the backend 403s it); render nothing
     // actionable if the dialog is somehow reached.
     if (!isAdmin) return null;
 
     function confirm() {
-        if (aIf === '' || bIf === '') return;
+        if ((!aPingOnly && aIf === '') || (!bPingOnly && bIf === '')) return;
         create.mutate(
             {
                 a_device_id: pending.aDeviceId,
-                a_interface_id: Number(aIf),
+                a_interface_id: aPingOnly ? null : Number(aIf),
                 b_device_id: pending.bDeviceId,
-                b_interface_id: Number(bIf),
+                b_interface_id: bPingOnly ? null : Number(bIf),
             },
             { onSuccess: onClose },
         );
@@ -194,7 +203,7 @@ export function LinkBinderDialog({
 
                     {isError && (
                         <p className="mt-3 text-xs text-rose-400/90">
-                            Couldn\'t create the link - they may already be linked, or an interface doesn\'t match its device.
+                            Couldn't create the link - they may already be linked, or an interface doesn't match its device.
                         </p>
                     )}
 

--- a/resources/js/features/topology/components/LinkHistoryDialog.tsx
+++ b/resources/js/features/topology/components/LinkHistoryDialog.tsx
@@ -155,12 +155,15 @@ function EditPanel({ link, devices, onSaved }: { link: Link; devices: Device[]; 
     const bDev = devices.find((d) => d.id === link.b_device_id);
     const aName = aDev?.name ?? `device ${link.a_device_id}`;
     const bName = bDev?.name ?? `device ${link.b_device_id}`;
-    const [aIf, setAIf] = useState(String(link.a_interface_id));
-    const [bIf, setBIf] = useState(String(link.b_interface_id));
+    const [aIf, setAIf] = useState(link.a_interface_id != null ? String(link.a_interface_id) : '');
+    const [bIf, setBIf] = useState(link.b_interface_id != null ? String(link.b_interface_id) : '');
     const [bwAb, setBwAb] = useState(link.bw_ab_mbps != null ? String(link.bw_ab_mbps) : '');
     const [bwBa, setBwBa] = useState(link.bw_ba_mbps != null ? String(link.bw_ba_mbps) : '');
     const update = useUpdateLink();
-    const ready = aIf !== '' && bIf !== '' && !update.isPending;
+    // A ping-only end has no interface to pick, so it's ready without a selection.
+    const aPingOnly = aDev?.poll_method === 'none';
+    const bPingOnly = bDev?.poll_method === 'none';
+    const ready = (aPingOnly || aIf !== '') && (bPingOnly || bIf !== '') && !update.isPending;
 
     const parse = (v: string): number | null => {
         const n = Number(v.trim());
@@ -173,9 +176,9 @@ function EditPanel({ link, devices, onSaved }: { link: Link; devices: Device[]; 
             {
                 id: link.id,
                 a_device_id: link.a_device_id,
-                a_interface_id: Number(aIf),
+                a_interface_id: aPingOnly ? null : Number(aIf),
                 b_device_id: link.b_device_id,
-                b_interface_id: Number(bIf),
+                b_interface_id: bPingOnly ? null : Number(bIf),
                 bw_ab_mbps: parse(bwAb),
                 bw_ba_mbps: parse(bwBa),
             },
@@ -204,7 +207,7 @@ function EditPanel({ link, devices, onSaved }: { link: Link; devices: Device[]; 
 
             {update.isError && (
                 <p className="text-xs text-rose-400/90">
-                    Couldn\'t update the link - they may already be linked, or an interface doesn\'t match its device.
+                    Couldn't update the link - they may already be linked, or an interface doesn't match its device.
                 </p>
             )}
 

--- a/resources/js/features/topology/components/MapCanvas.tsx
+++ b/resources/js/features/topology/components/MapCanvas.tsx
@@ -64,8 +64,8 @@ const edgeBtn = (active: boolean): string =>
 // carries its effective speed per direction: the link override, else
 // the slower of the two end interfaces - what util% is computed against.
 type EdgeMeta = {
-    aIf: number;
-    bIf: number;
+    aIf: number | null; // null = ping-only end (no interface, no throughput)
+    bIf: number | null;
     aDev: number;
     bDev: number;
     effAb: number | null; // A->B effective speed (Mbps) - util_ab denominator
@@ -83,10 +83,17 @@ const metaOf = (l: Link): EdgeMeta => ({
     effBa: l.eff_ba_mbps,
 });
 
-const linkUtil = (l: Link): UtilMap => ({
-    [l.a_interface_id]: { in: l.a_interface.util_in, out: l.a_interface.util_out, bin: l.a_interface.bps_in, bout: l.a_interface.bps_out },
-    [l.b_interface_id]: { in: l.b_interface.util_in, out: l.b_interface.util_out, bin: l.b_interface.bps_in, bout: l.b_interface.bps_out },
-});
+const linkUtil = (l: Link): UtilMap => {
+    const m: UtilMap = {};
+    // Skip ping-only ends (no interface -> nothing to key or fold).
+    if (l.a_interface_id !== null && l.a_interface) {
+        m[l.a_interface_id] = { in: l.a_interface.util_in, out: l.a_interface.util_out, bin: l.a_interface.bps_in, bout: l.a_interface.bps_out };
+    }
+    if (l.b_interface_id !== null && l.b_interface) {
+        m[l.b_interface_id] = { in: l.b_interface.util_in, out: l.b_interface.util_out, bin: l.b_interface.bps_in, bout: l.b_interface.bps_out };
+    }
+    return m;
+};
 
 // Max of a list ignoring null/undefined; null when there\'s nothing to compare.
 const maxNum = (vals: Array<number | null | undefined>): number | null => {
@@ -100,8 +107,8 @@ const maxNum = (vals: Array<number | null | undefined>): number | null => {
 //    speed, so the edge stays NEUTRAL (never ramped/green) per spec.
 //  - mbps (label): the busiest directional throughput (shown always, even with no speed).
 function computeData(meta: EdgeMeta, util: UtilMap, statusById: Record<number, DeviceStatus>): UtilEdgeData & EdgeMeta {
-    const a = util[meta.aIf];
-    const b = util[meta.bIf];
+    const a = meta.aIf !== null ? util[meta.aIf] : undefined;
+    const b = meta.bIf !== null ? util[meta.bIf] : undefined;
 
     // Directional throughput (bits/sec): A->B = traffic leaving A (a.bout) ~ arriving at B
     // (b.bin); B->A = b.bout ~ a.bin. Max to be robust to one end lacking a sample.
@@ -215,6 +222,9 @@ export function MapCanvas() {
                 status: d.status,
                 device_type: d.device_type,
                 util: deviceUtilRef.current[d.id] ?? null,
+                cpu: d.cpu_pct,
+                mem: d.mem_used_pct,
+                temp: d.temp_c,
             },
         }));
         const perDevice: Record<number, number> = {};
@@ -275,6 +285,7 @@ export function MapCanvas() {
                     [l.a_device_id, l.a_interface],
                     [l.b_device_id, l.b_interface],
                 ] as const) {
+                    if (!iface) continue; // ping-only end - no interface util to seed
                     const m = Math.max(iface.util_in ?? -1, iface.util_out ?? -1);
                     if (m >= 0) base[dev] = base[dev] != null ? Math.max(base[dev]!, m) : m;
                 }

--- a/resources/js/features/topology/hooks/useMapChannel.ts
+++ b/resources/js/features/topology/hooks/useMapChannel.ts
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { echo } from '../../../lib/echo';
 import { deviceKeys } from '../../devices/api/getDevices';
 import { linkKeys } from '../api/getLinks';
-import type { Device, DeviceStatus, InterfaceUtilUpdatedPayload } from '../../../types';
+import type { Device, DeviceMetricsUpdatedPayload, DeviceStatus, InterfaceUtilUpdatedPayload } from '../../../types';
 
 type DeviceStatusChangedPayload = {
     id: number;
@@ -48,6 +48,21 @@ export function useMapChannel(
 
         channel.listen('.InterfaceUtilUpdated', (e: InterfaceUtilUpdatedPayload) => {
             onUtil?.(e);
+        });
+
+        // Live cpu/mem/temp -> folded into the devices cache so both the map tiles and the
+        // inspector show current values (slower cadence than util, so a cache write per
+        // frame is cheap). Coalesced across devices in one event.
+        channel.listen('.DeviceMetricsUpdated', (e: DeviceMetricsUpdatedPayload) => {
+            const byId = new Map(e.devices.map((f) => [f.device_id, f]));
+            qc.setQueryData<Device[]>(
+                deviceKeys.list(),
+                (prev) =>
+                    prev?.map((d) => {
+                        const f = byId.get(d.id);
+                        return f ? { ...d, cpu_pct: f.cpu_pct, mem_used_pct: f.mem_used_pct, temp_c: f.temp_c } : d;
+                    }) ?? prev,
+            );
         });
 
         const connection = (

--- a/resources/js/features/topology/nodes/DeviceNode.tsx
+++ b/resources/js/features/topology/nodes/DeviceNode.tsx
@@ -1,15 +1,31 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react';
-import type { DeviceStatus, DeviceType } from '../../../types';
+import type { DeviceStatus, DeviceType, TileMetric } from '../../../types';
 import { StatusDot } from '../../../components/StatusDot';
 import { linkColor } from '../lib/linkColor';
+import { useDeviceTileMetric, setDeviceTileMetric } from '../../../lib/shellStore';
 
 export type DeviceNodeData = {
     label: string;
     mgmt_ip: string;
     status: DeviceStatus;
     device_type: DeviceType;
-    util: number | null; // device\'s busiest interface utilisation (live)
+    util: number | null; // device's busiest interface utilisation (live)
+    cpu: number | null; // resource metrics (live) - null when the device doesn't report them
+    mem: number | null;
+    temp: number | null;
 };
+
+// The tile can show any of these; the label is the little chip, next cycles on click.
+const METRICS: TileMetric[] = ['throughput', 'cpu', 'mem', 'temp'];
+const METRIC_LABEL: Record<TileMetric, string> = { throughput: 'LOAD', cpu: 'CPU', mem: 'MEM', temp: 'TEMP' };
+
+// Temperature isn't a percentage - colour by rough hot/warm/cool thresholds instead of
+// the utilisation ramp, and scale the bar against ~90C.
+function tempColor(c: number): string {
+    if (c >= 70) return '#f87171';
+    if (c >= 50) return '#fbbf24';
+    return '#34d399';
+}
 
 const handle = '!h-1.5 !w-1.5 !border-0 !bg-white/25';
 
@@ -49,11 +65,21 @@ const typeMeta: Record<DeviceType, { abbr: string; tint: string }> = {
     unknown: { abbr: 'DEV', tint: 'bg-white/5 text-white/40 ring-white/10' },
 };
 
-export function DeviceNode({ data, selected }: NodeProps) {
+export function DeviceNode({ id, data, selected }: NodeProps) {
     const d = data as unknown as DeviceNodeData;
     const meta = typeMeta[d.device_type] ?? typeMeta.unknown;
-    const util = d.util;
     const down = d.status === 'down';
+
+    // Which resource this tile shows (per-device, persisted). Clicking the chip cycles it.
+    const metric = useDeviceTileMetric(Number(id));
+    const cycle = () => setDeviceTileMetric(Number(id), METRICS[(METRICS.indexOf(metric) + 1) % METRICS.length]);
+
+    // Resolve the chosen metric to a bar width (0-100), a colour, and a value label.
+    const raw = metric === 'throughput' ? d.util : metric === 'cpu' ? d.cpu : metric === 'mem' ? d.mem : d.temp;
+    const isTemp = metric === 'temp';
+    const barPct = raw === null ? 0 : isTemp ? Math.min(Math.max((raw / 90) * 100, 0), 100) : Math.min(Math.max(raw, 0), 100);
+    const barColor = down ? 'var(--link-down)' : raw === null ? 'rgba(255,255,255,0.15)' : isTemp ? tempColor(raw) : linkColor(raw, false);
+    const valueLabel = raw === null ? '-' : isTemp ? `${Math.round(raw)}°` : `${raw.toFixed(raw < 10 ? 1 : 0)}%`;
 
     return (
         // Double-bezel: outer shell (machined tray) + inner core (glass plate). No backdrop-blur
@@ -84,19 +110,25 @@ export function DeviceNode({ data, selected }: NodeProps) {
                     <StatusDot status={d.status} className="mt-0.5 self-start" />
                 </div>
 
-                {/* Busiest-interface utilisation - bar + % (colour from the shared ramp). */}
+                {/* Chosen resource - clickable metric chip + bar + value. The chip carries
+                    `nodrag` so clicking it cycles the metric instead of dragging the node. */}
                 <div className="mt-2.5 flex items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); cycle(); }}
+                        title="Click to change the metric shown"
+                        className="nodrag shrink-0 rounded bg-white/5 px-1.5 py-0.5 text-[9px] font-semibold tracking-wide text-white/45 ring-1 ring-white/10 transition-colors hover:bg-white/10 hover:text-white/70"
+                    >
+                        {METRIC_LABEL[metric]}
+                    </button>
                     <div className="h-1 flex-1 overflow-hidden rounded-full bg-white/10">
                         <div
                             className="h-full rounded-full transition-all duration-500 ease-fluid"
-                            style={{
-                                width: `${Math.min(Math.max(util ?? 0, 0), 100)}%`,
-                                background: down ? 'var(--link-down)' : linkColor(util, false),
-                            }}
+                            style={{ width: `${barPct}%`, background: barColor }}
                         />
                     </div>
                     <span className="w-8 shrink-0 text-right text-[10px] tabular-nums text-white/45">
-                        {util === null ? '-' : `${util.toFixed(util < 10 ? 1 : 0)}%`}
+                        {valueLabel}
                     </span>
                 </div>
 

--- a/resources/js/features/upgrades/components/UpgradesView.tsx
+++ b/resources/js/features/upgrades/components/UpgradesView.tsx
@@ -1,0 +1,352 @@
+import { useState } from 'react';
+import { ArrowCircleUp, ArrowUp, ArrowDown, ArrowRight, CaretLeft, Check, LinkSimple } from '@phosphor-icons/react';
+import { useDevices } from '../../devices/api/getDevices';
+import { useUpgradePreflight, useUpgradeDevices, type UpgradePlanRow } from '../../devices/api/upgradeDevices';
+import { useIsAdmin } from '../../auth/api/auth';
+import { UpgradeStatusBadge } from '../../../components/UpgradeStatusBadge';
+import { StatusDot } from '../../../components/StatusDot';
+import { ConfirmDialog } from '../../../components/Dialog';
+import { pushToast } from '../../../lib/toast';
+import { UPGRADE_IN_PROGRESS, type Device } from '../../../types';
+
+/**
+ * Rolling upgrades: pick RouterOS devices, let the preflight order them
+ * furthest-downstream-first (so a reboot never cuts the path to gear still pending),
+ * eyeball the topology, re-order by hand if needed, then run them one at a time - the
+ * engine waits for each device to come back online before starting the next.
+ */
+export function UpgradesView() {
+    const isAdmin = useIsAdmin();
+    const { data: devices } = useDevices();
+    const preflight = useUpgradePreflight();
+    const upgrade = useUpgradeDevices();
+
+    const [selected, setSelected] = useState<Set<number>>(new Set());
+    const [order, setOrder] = useState<UpgradePlanRow[] | null>(null); // null = still selecting
+    const [confirming, setConfirming] = useState(false);
+    const [started, setStarted] = useState(false);
+
+    const candidates = (devices ?? []).filter((d) => d.poll_method === 'routeros');
+    const byId = new Map((devices ?? []).map((d) => [d.id, d]));
+    const running = started && order !== null && order.some((r) => {
+        const s = byId.get(r.device_id)?.upgrade_status;
+        return s ? UPGRADE_IN_PROGRESS.has(s) : false;
+    });
+
+    if (!isAdmin) {
+        return <Placeholder>Rolling upgrades are an admin-only action.</Placeholder>;
+    }
+
+    function toggle(id: number) {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            next.has(id) ? next.delete(id) : next.add(id);
+            return next;
+        });
+    }
+
+    async function plan() {
+        const ids = [...selected];
+        if (ids.length === 0) return;
+        try {
+            const p = await preflight.mutateAsync({ deviceIds: ids });
+            // Order the rows by the preflight's furthest-first order.
+            const rows = p.order.map((id) => p.plan.find((r) => r.device_id === id)).filter((r): r is UpgradePlanRow => !!r);
+            setOrder(rows);
+            setStarted(false);
+        } catch {
+            pushToast({ title: "Couldn't work out the upgrade order", tone: 'down' });
+        }
+    }
+
+    function move(i: number, dir: -1 | 1) {
+        setOrder((o) => {
+            if (!o) return o;
+            const j = i + dir;
+            if (j < 0 || j >= o.length) return o;
+            const a = [...o];
+            [a[i], a[j]] = [a[j], a[i]];
+            return a;
+        });
+    }
+
+    function start() {
+        if (!order) return;
+        const ids = order.map((r) => r.device_id);
+        upgrade.mutate(
+            { deviceIds: ids, ordered: true, explicitOrder: true },
+            {
+                onSuccess: () => {
+                    setStarted(true);
+                    pushToast({ title: 'Rolling upgrade started', detail: 'Each device upgrades once the one before it is back online.', tone: 'info' });
+                },
+                onError: () => pushToast({ title: "Couldn't start the upgrade", tone: 'down' }),
+            },
+        );
+        setConfirming(false);
+    }
+
+    const upgradable = order?.filter((r) => r.action === 'upgrade').length ?? 0;
+
+    return (
+        <div className="mx-auto flex h-full w-full max-w-4xl flex-col gap-5 overflow-y-auto p-6">
+            <header className="flex items-center gap-3">
+                <span className="grid h-10 w-10 place-items-center rounded-xl bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-400/20">
+                    <ArrowCircleUp weight="light" className="h-6 w-6" />
+                </span>
+                <div>
+                    <h1 className="text-lg font-bold tracking-tight text-white">Rolling upgrades</h1>
+                    <p className="text-sm text-white/45">Upgrade RouterOS gear in order, furthest out first, one at a time.</p>
+                </div>
+            </header>
+
+            {order === null ? (
+                <SelectStep
+                    candidates={candidates}
+                    selected={selected}
+                    onToggle={toggle}
+                    onSelectAll={() => setSelected(new Set(candidates.map((d) => d.id)))}
+                    onClear={() => setSelected(new Set())}
+                    onPlan={plan}
+                    planning={preflight.isPending}
+                />
+            ) : (
+                <ReviewStep
+                    order={order}
+                    byId={byId}
+                    started={started}
+                    running={running}
+                    onMove={move}
+                    onBack={() => { setOrder(null); setStarted(false); }}
+                    onStart={() => setConfirming(true)}
+                    upgradable={upgradable}
+                    starting={upgrade.isPending}
+                />
+            )}
+
+            {confirming && order && (
+                <ConfirmDialog
+                    title="Start rolling upgrade"
+                    icon={<ArrowCircleUp weight="light" className="h-5 w-5" />}
+                    message={
+                        <>
+                            Upgrade <span className="font-semibold text-white/85">{upgradable}</span> device{upgradable === 1 ? '' : 's'} in this order,
+                            one at a time. Each device reboots into the new firmware and the next only starts once it is back online. This reboots live gear.
+                        </>
+                    }
+                    confirmLabel={`Upgrade ${upgradable}`}
+                    tone="danger"
+                    busy={upgrade.isPending}
+                    onConfirm={start}
+                    onClose={() => setConfirming(false)}
+                />
+            )}
+        </div>
+    );
+}
+
+function SelectStep({
+    candidates,
+    selected,
+    onToggle,
+    onSelectAll,
+    onClear,
+    onPlan,
+    planning,
+}: {
+    candidates: Device[];
+    selected: Set<number>;
+    onToggle: (id: number) => void;
+    onSelectAll: () => void;
+    onClear: () => void;
+    onPlan: () => void;
+    planning: boolean;
+}) {
+    return (
+        <>
+            <div className="flex items-center justify-between">
+                <p className="text-xs font-medium uppercase tracking-wide text-white/40">
+                    Select devices - {selected.size} of {candidates.length}
+                </p>
+                <div className="flex items-center gap-2 text-xs">
+                    <button onClick={onSelectAll} className="rounded-lg px-2 py-1 text-white/60 hover:bg-white/5 hover:text-white/90">Select all</button>
+                    <button onClick={onClear} className="rounded-lg px-2 py-1 text-white/60 hover:bg-white/5 hover:text-white/90">Clear</button>
+                </div>
+            </div>
+
+            {candidates.length === 0 ? (
+                <Placeholder>No RouterOS devices to upgrade. Only RouterOS gear can be upgraded.</Placeholder>
+            ) : (
+                <div className="space-y-1.5">
+                    {candidates.map((d) => {
+                        const on = selected.has(d.id);
+                        return (
+                            <button
+                                key={d.id}
+                                onClick={() => onToggle(d.id)}
+                                className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left ring-1 transition-colors ${
+                                    on ? 'bg-emerald-500/10 ring-emerald-400/30' : 'bg-white/[0.03] ring-white/[0.06] hover:bg-white/[0.05]'
+                                }`}
+                            >
+                                <span className={`grid h-5 w-5 shrink-0 place-items-center rounded-md ring-1 ${on ? 'bg-emerald-500 ring-emerald-400 text-emerald-950' : 'ring-white/20'}`}>
+                                    {on && <Check weight="bold" className="h-3.5 w-3.5" />}
+                                </span>
+                                <StatusDot status={d.status} />
+                                <span className="min-w-0 flex-1 truncate text-sm font-medium text-white/85">{d.name}</span>
+                                <span className="shrink-0 font-mono text-[11px] text-white/40">{d.mgmt_ip}</span>
+                                <span className="w-24 shrink-0 text-right text-[11px] text-white/50">
+                                    {d.os_version ? `v${d.os_version}` : 'unknown'}
+                                    {d.latest_version && d.os_version !== d.latest_version ? ` -> v${d.latest_version}` : ''}
+                                </span>
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
+
+            <div className="flex justify-end">
+                <button
+                    onClick={onPlan}
+                    disabled={selected.size === 0 || planning}
+                    className="group flex items-center gap-2 rounded-full bg-emerald-500 py-2 pl-5 pr-2 text-sm font-semibold text-emerald-950 shadow-[0_8px_24px_-8px_rgba(16,185,129,0.6)] transition hover:bg-emerald-400 active:scale-[0.98] disabled:opacity-40"
+                >
+                    <span>{planning ? 'Planning...' : 'Plan upgrade order'}</span>
+                    <span className="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-950/15 transition-transform group-hover:translate-x-0.5">
+                        <ArrowRight weight="bold" className="h-4 w-4" />
+                    </span>
+                </button>
+            </div>
+        </>
+    );
+}
+
+function ReviewStep({
+    order,
+    byId,
+    started,
+    running,
+    onMove,
+    onBack,
+    onStart,
+    upgradable,
+    starting,
+}: {
+    order: UpgradePlanRow[];
+    byId: Map<number, Device>;
+    started: boolean;
+    running: boolean;
+    onMove: (i: number, dir: -1 | 1) => void;
+    onBack: () => void;
+    onStart: () => void;
+    upgradable: number;
+    starting: boolean;
+}) {
+    return (
+        <>
+            <div className="flex items-center justify-between">
+                <p className="text-xs font-medium uppercase tracking-wide text-white/40">
+                    Upgrade order - furthest out first{started ? '' : ' (drag to re-order with the arrows)'}
+                </p>
+                {!started && (
+                    <button onClick={onBack} className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-white/60 hover:bg-white/5 hover:text-white/90">
+                        <CaretLeft weight="bold" className="h-3.5 w-3.5" /> Change selection
+                    </button>
+                )}
+            </div>
+
+            <div className="space-y-1.5">
+                {order.map((row, i) => {
+                    const live = byId.get(row.device_id);
+                    const skip = row.action === 'skip';
+                    return (
+                        <div
+                            key={row.device_id}
+                            className={`flex items-center gap-3 rounded-xl px-3 py-2.5 ring-1 ${
+                                skip ? 'bg-white/[0.015] ring-white/[0.05] opacity-60' : 'bg-white/[0.03] ring-white/[0.06]'
+                            }`}
+                        >
+                            <span className="w-5 shrink-0 text-center text-xs font-semibold tabular-nums text-white/35">{i + 1}</span>
+
+                            {!started && !skip ? (
+                                <span className="flex shrink-0 flex-col">
+                                    <button onClick={() => onMove(i, -1)} disabled={i === 0} className="text-white/30 hover:text-white/80 disabled:opacity-20">
+                                        <ArrowUp weight="bold" className="h-3 w-3" />
+                                    </button>
+                                    <button onClick={() => onMove(i, 1)} disabled={i === order.length - 1} className="text-white/30 hover:text-white/80 disabled:opacity-20">
+                                        <ArrowDown weight="bold" className="h-3 w-3" />
+                                    </button>
+                                </span>
+                            ) : (
+                                <span className="w-3 shrink-0" />
+                            )}
+
+                            <span className="grid h-6 w-6 shrink-0 place-items-center rounded-md bg-white/[0.06] text-[10px] font-semibold text-white/45 ring-1 ring-white/10" title={`${row.depth} hop(s) from the core`}>
+                                {row.depth}
+                            </span>
+
+                            <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-2">
+                                    <StatusDot status={row.status} />
+                                    <span className="truncate text-sm font-medium text-white/85">{row.name}</span>
+                                    {row.os_version && (
+                                        <span className="shrink-0 font-mono text-[10px] text-white/35">
+                                            v{row.os_version}{row.latest_version && row.latest_version !== row.os_version ? ` -> v${row.latest_version}` : ''}
+                                        </span>
+                                    )}
+                                </div>
+                                {(row.parent_name || row.neighbours.length > 0) && (
+                                    <div className="mt-0.5 flex items-center gap-1 truncate text-[11px] text-white/35">
+                                        <LinkSimple weight="bold" className="h-3 w-3 shrink-0" />
+                                        <span className="truncate">
+                                            {[row.parent_name ? `up: ${row.parent_name}` : null, row.neighbours.length ? row.neighbours.join(', ') : null]
+                                                .filter(Boolean)
+                                                .join('  -  ')}
+                                        </span>
+                                    </div>
+                                )}
+                            </div>
+
+                            <span className="shrink-0 text-right">
+                                {skip ? (
+                                    <span className="text-[11px] text-white/40" title={row.reason ?? undefined}>skip - {row.reason}</span>
+                                ) : started && live ? (
+                                    <UpgradeStatusBadge device={live} />
+                                ) : (
+                                    <span className="text-[11px] font-medium text-emerald-300/80">will upgrade</span>
+                                )}
+                            </span>
+                        </div>
+                    );
+                })}
+            </div>
+
+            {!started ? (
+                <div className="flex items-center justify-between">
+                    <p className="text-xs text-white/40">{upgradable} of {order.length} will upgrade; the rest are skipped.</p>
+                    <button
+                        onClick={onStart}
+                        disabled={upgradable === 0 || starting}
+                        className="group flex items-center gap-2 rounded-full bg-emerald-500 py-2 pl-5 pr-2 text-sm font-semibold text-emerald-950 shadow-[0_8px_24px_-8px_rgba(16,185,129,0.6)] transition hover:bg-emerald-400 active:scale-[0.98] disabled:opacity-40"
+                    >
+                        <span>Start rolling upgrade</span>
+                        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-950/15 transition-transform group-hover:translate-x-0.5">
+                            <ArrowRight weight="bold" className="h-4 w-4" />
+                        </span>
+                    </button>
+                </div>
+            ) : (
+                <p className="text-center text-xs text-white/45">
+                    {running ? 'Rolling upgrade in progress - each device starts once the one before it is back online.' : 'Rolling upgrade finished.'}
+                </p>
+            )}
+        </>
+    );
+}
+
+function Placeholder({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="grid flex-1 place-items-center rounded-2xl bg-white/[0.02] p-10 text-center text-sm text-white/40 ring-1 ring-white/[0.06]">
+            {children}
+        </div>
+    );
+}

--- a/resources/js/lib/shellStore.ts
+++ b/resources/js/lib/shellStore.ts
@@ -6,7 +6,7 @@ import { useSyncExternalStore } from 'react';
  * Lives in the shared core so the shell and the topology feature both read/write
  * it without a cross-feature import. No provider needed.
  */
-export type View = 'map' | 'dashboard' | 'devices' | 'discovery' | 'outages' | 'alerts' | 'settings' | 'import';
+export type View = 'map' | 'dashboard' | 'devices' | 'discovery' | 'outages' | 'alerts' | 'upgrades' | 'settings' | 'import';
 
 /** Per-device inspector view prefs. */
 export type ChartMode = 'util' | 'rate';
@@ -53,6 +53,7 @@ const VIEW_TO_PATH: Record<View, string> = {
     discovery: '/discovery',
     outages: '/outages',
     alerts: '/alerts',
+    upgrades: '/upgrades',
     settings: '/settings',
     import: '/import',
 };

--- a/resources/js/lib/shellStore.ts
+++ b/resources/js/lib/shellStore.ts
@@ -6,7 +6,7 @@ import { useSyncExternalStore } from 'react';
  * Lives in the shared core so the shell and the topology feature both read/write
  * it without a cross-feature import. No provider needed.
  */
-export type View = 'map' | 'dashboard' | 'devices' | 'discovery' | 'outages' | 'alerts' | 'upgrades' | 'settings' | 'import';
+export type View = 'map' | 'dashboard' | 'devices' | 'discovery' | 'outages' | 'alerts' | 'upgrades' | 'backups' | 'settings' | 'import';
 
 /** Per-device inspector view prefs. */
 export type ChartMode = 'util' | 'rate';
@@ -54,6 +54,7 @@ const VIEW_TO_PATH: Record<View, string> = {
     outages: '/outages',
     alerts: '/alerts',
     upgrades: '/upgrades',
+    backups: '/backups',
     settings: '/settings',
     import: '/import',
 };

--- a/resources/js/lib/shellStore.ts
+++ b/resources/js/lib/shellStore.ts
@@ -11,6 +11,8 @@ export type View = 'map' | 'dashboard' | 'devices' | 'discovery' | 'outages' | '
 /** Per-device inspector view prefs. */
 export type ChartMode = 'util' | 'rate';
 export type IfaceFilter = 'all' | 'linked' | 'traffic';
+/** Which resource a device's map tile shows. Re-exported from types for store use. */
+export type TileMetric = 'throughput' | 'cpu' | 'mem' | 'temp';
 
 /** Map link geometry - curved bezier (default) or straight point-to-point. */
 export type EdgeStyle = 'curved' | 'straight';
@@ -30,6 +32,7 @@ type ShellState = {
     // returns a stable scalar - a fresh object per render would loop useSyncExternalStore.
     chartModeById: Record<number, ChartMode>;
     ifaceFilterById: Record<number, IfaceFilter>;
+    tileMetricById: Record<number, TileMetric>; // which resource each map tile shows
     edgeStyle: EdgeStyle; // map link geometry - curved (default) or straight
     layoutKind: LayoutKind; // last-chosen auto-layout algorithm
     wallboard: boolean; // big-screen / TV presentation mode
@@ -72,6 +75,7 @@ type Persisted = Pick<
     | 'activeMapId'
     | 'chartModeById'
     | 'ifaceFilterById'
+    | 'tileMetricById'
     | 'edgeStyle'
     | 'layoutKind'
     | 'wallboard'
@@ -99,6 +103,7 @@ let state: ShellState = {
     activeMapId: saved.activeMapId ?? null,
     chartModeById: saved.chartModeById ?? {},
     ifaceFilterById: saved.ifaceFilterById ?? {},
+    tileMetricById: saved.tileMetricById ?? {},
     edgeStyle: saved.edgeStyle ?? 'curved',
     layoutKind: saved.layoutKind ?? 'smart',
     wallboard: saved.wallboard ?? false,
@@ -112,13 +117,13 @@ function persist(): void {
     if (typeof window === 'undefined') return;
     try {
         const {
-            selectedDeviceId, activeMapId, chartModeById, ifaceFilterById, edgeStyle, layoutKind, wallboard,
+            selectedDeviceId, activeMapId, chartModeById, ifaceFilterById, tileMetricById, edgeStyle, layoutKind, wallboard,
             dashboardAll, dashboardIds, dashboardCycleS,
         } = state;
         window.localStorage.setItem(
             STORAGE_KEY,
             JSON.stringify({
-                selectedDeviceId, activeMapId, chartModeById, ifaceFilterById, edgeStyle, layoutKind, wallboard,
+                selectedDeviceId, activeMapId, chartModeById, ifaceFilterById, tileMetricById, edgeStyle, layoutKind, wallboard,
                 dashboardAll, dashboardIds, dashboardCycleS,
             }),
         );
@@ -225,6 +230,18 @@ export function setDeviceIfaceFilter(id: number, filter: IfaceFilter): void {
 
 export function useDeviceIfaceFilter(id: number): IfaceFilter {
     return useSyncExternalStore(subscribe, () => state.ifaceFilterById[id] ?? 'all');
+}
+
+// Per-device map-tile resource: throughput (default) / cpu / mem / temp. Persisted so a
+// tile keeps showing the metric the operator picked across reloads.
+export function setDeviceTileMetric(id: number, metric: TileMetric): void {
+    if ((state.tileMetricById[id] ?? 'throughput') === metric) return;
+    state = { ...state, tileMetricById: { ...state.tileMetricById, [id]: metric } };
+    emit();
+}
+
+export function useDeviceTileMetric(id: number): TileMetric {
+    return useSyncExternalStore(subscribe, () => state.tileMetricById[id] ?? 'throughput');
 }
 
 // Map edge geometry: curved (bezier, default) or straight. Global +

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -35,6 +35,7 @@ export interface Device {
     map_x: number;
     map_y: number;
     credential_id: number | null;
+    ssh_credential_id: number | null; // dedicated SSH cred for backups (separate from poll cred)
     agent_id: number | null;
     // NOC-console metadata.
     device_type: DeviceType;
@@ -162,7 +163,7 @@ export interface EngineSetting {
 export interface Credential {
     id: number;
     name: string;
-    type: 'snmp' | 'routeros';
+    type: 'snmp' | 'routeros' | 'ssh';
     api_port: number;
     has_secret: boolean;
     device_count: number;

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -82,7 +82,6 @@ export const BACKUP_IN_PROGRESS: ReadonlySet<BackupStatus> = new Set(['pending']
  */
 export const RUSTED_DRIVERS: { value: string; label: string }[] = [
     { value: 'mikrotik_routeros', label: 'MikroTik RouterOS' },
-    { value: 'mikrotik_routeros_api', label: 'MikroTik RouterOS (API)' },
     { value: 'cisco_ios', label: 'Cisco IOS' },
     { value: 'cisco_nxos', label: 'Cisco Nexus (NX-OS)' },
     { value: 'cisco_asa', label: 'Cisco ASA' },

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -92,6 +92,23 @@ export const RUSTED_DRIVERS: { value: string; label: string }[] = [
     { value: 'generic', label: 'Generic' },
 ];
 
+/** One stored config version (a git commit of the device's config file). */
+export interface BackupVersion {
+    commit: string;
+    date: string;
+    subject: string;
+}
+
+/** Automatic-backup schedule (App\Support\BackupSchedule). */
+export type BackupFrequency = 'hourly' | 'every_6h' | 'every_12h' | 'daily' | 'weekly';
+export interface BackupScheduleConfig {
+    enabled: boolean;
+    frequency: BackupFrequency;
+    hour: number;
+    weekday: number;
+    last_run_at: string | null;
+}
+
 /** One row of a device\'s backup history (proxied from Rusted). */
 export interface BackupHistoryEntry {
     started_at: string | null;

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -53,6 +53,12 @@ export interface Device {
     // Interface-discovery visibility.
     discovery_error: string | null;
     discovered_at: string | null;
+    // Resource metrics (latest poll) - the map tile can show any of these. Null = not
+    // read (unsupported OID / never polled), never treated as zero.
+    cpu_pct: number | null;
+    mem_used_pct: number | null;
+    temp_c: number | null;
+    metrics_at: string | null;
     // Config-backup mirror - last Rusted run, cached on the device.
     backup_enabled: boolean;
     backup_driver: string | null;
@@ -127,11 +133,13 @@ export interface NetworkInterface {
 export interface Link {
     id: number;
     a_device_id: number;
-    a_interface_id: number;
+    // Interface ends are null for a ping-only device (no interfaces) - the link then
+    // draws device-to-device and takes its throughput from whichever end has one.
+    a_interface_id: number | null;
     b_device_id: number;
-    b_interface_id: number;
-    a_interface: NetworkInterface;
-    b_interface: NetworkInterface;
+    b_interface_id: number | null;
+    a_interface: NetworkInterface | null;
+    b_interface: NetworkInterface | null;
     // Per-link bandwidth override + resolved effective speed per direction.
     // bw_* null = derive from the slowest end; eff_* is the value util% is computed against.
     bw_ab_mbps: number | null;
@@ -286,6 +294,31 @@ export interface InterfaceSample {
     util_out: number | null;
     bps_in: number | null;
     bps_out: number | null;
+}
+
+// Which resource a device's map tile shows. 'throughput' = busiest-interface util
+// (the default, unchanged); the rest come from the device-metrics pipeline.
+export type TileMetric = 'throughput' | 'cpu' | 'mem' | 'temp';
+
+// Live device-metrics event (App\Events\DeviceMetricsUpdated) - coalesced across devices.
+export interface DeviceMetricsFrame {
+    device_id: number;
+    cpu_pct: number | null;
+    mem_used_pct: number | null;
+    temp_c: number | null;
+}
+
+export interface DeviceMetricsUpdatedPayload {
+    devices: DeviceMetricsFrame[];
+    device_count: number;
+}
+
+// Recent history - a bucketed cpu/mem/temp point from the device metric-samples endpoint.
+export interface DeviceMetricSample {
+    ts: string;
+    cpu_pct: number | null;
+    mem_used_pct: number | null;
+    temp_c: number | null;
 }
 
 // Auto-discovery - mirrors SubnetResource / DiscoveryCandidateResource.

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -29,6 +29,7 @@ export interface Device {
     name: string;
     mgmt_ip: string;
     poll_method: PollMethod;
+    monitored: boolean; // false = polling paused (no throughput/metrics collected)
     status: DeviceStatus;
     last_change: string | null;
     map_x: number;

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -82,6 +82,7 @@ export const BACKUP_IN_PROGRESS: ReadonlySet<BackupStatus> = new Set(['pending']
  */
 export const RUSTED_DRIVERS: { value: string; label: string }[] = [
     { value: 'mikrotik_routeros', label: 'MikroTik RouterOS' },
+    { value: 'mikrotik_routeros_api', label: 'MikroTik RouterOS (API)' },
     { value: 'cisco_ios', label: 'Cisco IOS' },
     { value: 'cisco_nxos', label: 'Cisco Nexus (NX-OS)' },
     { value: 'cisco_asa', label: 'Cisco ASA' },

--- a/routes/api.php
+++ b/routes/api.php
@@ -97,6 +97,9 @@ Route::middleware(['auth:sanctum', RestrictWritesToAdmins::class])->group(functi
         ->name('interfaces.samples');
     Route::get('devices/{device}/samples', [InterfaceSampleController::class, 'device'])
         ->name('devices.samples');
+    // Recent history: bucketed cpu/mem/temp series for one device (resource chart).
+    Route::get('devices/{device}/metric-samples', [InterfaceSampleController::class, 'metrics'])
+        ->name('devices.metric-samples');
 
     // Topology links (interface-to-interface). Update re-binds either end.
     Route::apiResource('links', LinkController::class)->only(['index', 'store', 'update', 'destroy']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -86,6 +86,9 @@ Route::middleware(['auth:sanctum', RestrictWritesToAdmins::class])->group(functi
         ->name('devices.backup.config');
     Route::post('devices/{device}/backups', [DeviceBackupController::class, 'run'])
         ->middleware('throttle:10,1')->name('devices.backups.run');
+    // Bootstrap key-based SSH on a MikroTik over the API (installs a generated key).
+    Route::post('devices/{device}/provision-ssh-key', [DeviceBackupController::class, 'provisionKey'])
+        ->middleware('throttle:6,1')->name('devices.provision-ssh-key');
     Route::get('devices/{device}/backups', [DeviceBackupController::class, 'history'])
         ->name('devices.backups.history');
     Route::get('devices/{device}/backups/latest', [DeviceBackupController::class, 'latest'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,6 +93,13 @@ Route::middleware(['auth:sanctum', RestrictWritesToAdmins::class])->group(functi
         ->name('devices.backups.history');
     Route::get('devices/{device}/backups/latest', [DeviceBackupController::class, 'latest'])
         ->name('devices.backups.latest');
+    // Git-backed version history + view an old version + diff between versions.
+    Route::get('devices/{device}/backups/versions', [DeviceBackupController::class, 'versions'])
+        ->name('devices.backups.versions');
+    Route::get('devices/{device}/backups/config', [DeviceBackupController::class, 'configAt'])
+        ->name('devices.backups.config-at');
+    Route::get('devices/{device}/backups/diff', [DeviceBackupController::class, 'diff'])
+        ->name('devices.backups.diff');
 
     // Recent history: a bucketed util/bps series for one interface, or the
     // whole device's total throughput (bps summed across its interfaces).
@@ -136,6 +143,10 @@ Route::middleware(['auth:sanctum', RestrictWritesToAdmins::class])->group(functi
     // reachability check. Token/password encrypted at rest, never returned.
     Route::get('settings/backup', [BackupSettingController::class, 'show'])->name('settings.backup.show');
     Route::put('settings/backup', [BackupSettingController::class, 'update'])->name('settings.backup.update');
+    Route::get('settings/backup-schedule', [BackupSettingController::class, 'schedule'])->name('settings.backup.schedule.show');
+    Route::put('settings/backup-schedule', [BackupSettingController::class, 'updateSchedule'])->name('settings.backup.schedule.update');
+    Route::post('backups/run-all', [BackupSettingController::class, 'runAll'])
+        ->middleware('throttle:6,1')->name('backups.run-all');
     Route::post('settings/backup/test', [BackupSettingController::class, 'test'])
         ->middleware('throttle:6,1')->name('settings.backup.test');
     Route::apiResource('credentials', CredentialController::class)->only(['index', 'store', 'update', 'destroy']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -17,4 +17,7 @@ Schedule::job(new ManageHistoryPartitionsJob)->daily()->name('history-partitions
 // Device config backups: nightly, fan out one backup job per
 // backup-enabled device onto the isolated `backup` queue (the SSH capture runs in the
 // Rusted sidecar). Off-peak so a slow fleet-wide sweep doesn't compete with the day.
-Schedule::command('mymate:backup:run --all')->dailyAt('02:30')->name('device-backups')->withoutOverlapping();
+// Runs hourly; the command fires only when the operator-configured cadence
+// (App\Support\BackupSchedule, editable on the Backups page) is due - so changing the
+// schedule takes effect without restarting the scheduler.
+Schedule::command('mymate:backup:run --scheduled')->hourly()->name('device-backups')->withoutOverlapping();

--- a/tests/Feature/BackupConfigureCommandTest.php
+++ b/tests/Feature/BackupConfigureCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\BackupSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BackupConfigureCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_configures_the_backup_engine_from_url_and_token(): void
+    {
+        $this->artisan('mymate:backup:configure', ['--url' => 'http://127.0.0.1:8410', '--token' => 'abc123'])
+            ->assertSuccessful();
+
+        $settings = app(BackupSettings::class);
+        $this->assertSame('http://127.0.0.1:8410', $settings->apiUrl());
+        $this->assertSame('abc123', $settings->apiToken());
+        $this->assertTrue($settings->configured());
+    }
+
+    public function test_reads_the_token_from_a_rusted_config_file(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'rusted');
+        file_put_contents($path, "db = \"x\"\napi_addr  = \"127.0.0.1:8410\"\napi_token = \"tok-from-file\"\nsecret = \"s\"\n");
+
+        $this->artisan('mymate:backup:configure', ['--url' => 'http://127.0.0.1:8410', '--from-rusted' => $path])
+            ->assertSuccessful();
+
+        $this->assertSame('tok-from-file', app(BackupSettings::class)->apiToken());
+        @unlink($path);
+    }
+
+    public function test_fails_without_a_token(): void
+    {
+        $this->artisan('mymate:backup:configure', ['--url' => 'http://127.0.0.1:8410'])
+            ->assertFailed();
+    }
+}

--- a/tests/Feature/BackupScheduleTest.php
+++ b/tests/Feature/BackupScheduleTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\BackupSchedule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class BackupScheduleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function schedule(): BackupSchedule
+    {
+        return app(BackupSchedule::class);
+    }
+
+    public function test_disabled_is_never_due(): void
+    {
+        $s = $this->schedule();
+        $s->save(['enabled' => false, 'frequency' => 'hourly', 'hour' => 2, 'weekday' => 0]);
+        $this->assertFalse($s->due(Carbon::parse('2026-07-13 02:00:00')));
+    }
+
+    public function test_daily_fires_at_the_configured_hour_once_per_day(): void
+    {
+        $s = $this->schedule();
+        $s->save(['enabled' => true, 'frequency' => 'daily', 'hour' => 2, 'weekday' => 0]);
+
+        $this->assertFalse($s->due(Carbon::parse('2026-07-13 01:00:00'))); // wrong hour
+        $this->assertTrue($s->due(Carbon::parse('2026-07-13 02:30:00')));   // right hour, not run yet
+
+        $s->markRan(Carbon::parse('2026-07-13 02:30:00'));
+        $this->assertFalse($s->due(Carbon::parse('2026-07-13 02:45:00'))); // already ran today
+        $this->assertTrue($s->due(Carbon::parse('2026-07-14 02:05:00')));  // next day
+    }
+
+    public function test_interval_frequency_respects_the_gap(): void
+    {
+        $s = $this->schedule();
+        $s->save(['enabled' => true, 'frequency' => 'every_6h', 'hour' => 2, 'weekday' => 0]);
+
+        $this->assertTrue($s->due(Carbon::parse('2026-07-13 00:00:00'))); // never run -> due
+        $s->markRan(Carbon::parse('2026-07-13 00:00:00'));
+        $this->assertFalse($s->due(Carbon::parse('2026-07-13 03:00:00'))); // only 3h later
+        $this->assertTrue($s->due(Carbon::parse('2026-07-13 06:00:00')));  // 6h later
+    }
+
+    public function test_endpoint_reads_and_writes_the_schedule(): void
+    {
+        $this->actingAsUser();
+
+        $this->getJson('/api/settings/backup-schedule')
+            ->assertOk()
+            ->assertJsonPath('data.frequency', 'daily'); // default
+
+        $this->putJson('/api/settings/backup-schedule', ['enabled' => true, 'frequency' => 'weekly', 'hour' => 3, 'weekday' => 1])
+            ->assertOk()
+            ->assertJsonPath('data.frequency', 'weekly')
+            ->assertJsonPath('data.hour', 3);
+    }
+}

--- a/tests/Feature/CredentialApiTest.php
+++ b/tests/Feature/CredentialApiTest.php
@@ -54,6 +54,22 @@ class CredentialApiTest extends TestCase
             ->assertStatus(422)->assertJsonValidationErrors(['snmp_community']);
     }
 
+    public function test_creates_an_ssh_credential_for_backups(): void
+    {
+        $this->actingAsUser();
+
+        $this->postJson('/api/credentials', [
+            'name' => 'Backup SSH', 'type' => 'ssh', 'username' => 'backup', 'password' => 'sup3r-secret-1',
+        ])
+            ->assertCreated()
+            ->assertJsonPath('data.type', 'ssh')
+            ->assertJsonPath('data.has_secret', true);
+
+        // SSH needs a username + password, like RouterOS.
+        $this->postJson('/api/credentials', ['name' => 'Y', 'type' => 'ssh'])
+            ->assertStatus(422)->assertJsonValidationErrors(['username', 'password']);
+    }
+
     public function test_deletes_a_credential(): void
     {
         $this->actingAsUser();

--- a/tests/Feature/DeviceApiTest.php
+++ b/tests/Feature/DeviceApiTest.php
@@ -65,6 +65,17 @@ class DeviceApiTest extends TestCase
         $this->assertDatabaseHas('devices', ['id' => $device->id, 'name' => 'New']);
     }
 
+    public function test_it_toggles_monitoring(): void
+    {
+        $device = Device::factory()->create(['monitored' => true]);
+
+        $this->putJson("/api/devices/{$device->id}", ['monitored' => false])
+            ->assertOk()
+            ->assertJsonPath('data.monitored', false);
+
+        $this->assertDatabaseHas('devices', ['id' => $device->id, 'monitored' => false]);
+    }
+
     public function test_it_persists_position(): void
     {
         $device = Device::factory()->create(['map_x' => 0, 'map_y' => 0]);

--- a/tests/Feature/DeviceApiTest.php
+++ b/tests/Feature/DeviceApiTest.php
@@ -65,6 +65,18 @@ class DeviceApiTest extends TestCase
         $this->assertDatabaseHas('devices', ['id' => $device->id, 'name' => 'New']);
     }
 
+    public function test_it_attaches_a_dedicated_ssh_credential(): void
+    {
+        $device = Device::factory()->create();
+        $ssh = \App\Models\Credential::factory()->ssh()->create();
+
+        $this->putJson("/api/devices/{$device->id}", ['ssh_credential_id' => $ssh->id])
+            ->assertOk()
+            ->assertJsonPath('data.ssh_credential_id', $ssh->id);
+
+        $this->assertDatabaseHas('devices', ['id' => $device->id, 'ssh_credential_id' => $ssh->id]);
+    }
+
     public function test_it_toggles_monitoring(): void
     {
         $device = Device::factory()->create(['monitored' => true]);

--- a/tests/Feature/DeviceMetricSampleApiTest.php
+++ b/tests/Feature/DeviceMetricSampleApiTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Device;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DeviceMetricSampleApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actingAsUser();
+    }
+
+    private function insert(int $deviceId, Carbon $ts, ?float $cpu, ?float $mem, ?float $temp): void
+    {
+        DB::table('device_metric_samples')->insert([
+            'device_id' => $deviceId,
+            'ts' => $ts->format('Y-m-d H:i:s'),
+            'cpu_pct' => $cpu,
+            'mem_used_pct' => $mem,
+            'temp_c' => $temp,
+        ]);
+    }
+
+    public function test_returns_a_bucketed_averaged_metric_series(): void
+    {
+        $device = Device::factory()->create();
+        $base = now()->subMinutes(5);
+        $this->insert($device->id, $base, 10, 40, 50);
+        $this->insert($device->id, $base->copy()->addSecond(), 30, 60, 52);
+        config(['mymate.history.max_points' => 10]);
+
+        $data = $this->getJson(
+            "/api/devices/{$device->id}/metric-samples?from=".now()->subMinutes(10)->format('Y-m-d\TH:i:s').'&to='.now()->format('Y-m-d\TH:i:s')
+        )->assertOk()->json('data');
+
+        $bucket = collect($data)->first(fn ($r) => $r['cpu_pct'] !== null);
+        $this->assertEqualsWithDelta(20.0, $bucket['cpu_pct'], 0.001);   // (10+30)/2
+        $this->assertEqualsWithDelta(50.0, $bucket['mem_used_pct'], 0.001); // (40+60)/2
+        $this->assertEqualsWithDelta(51.0, $bucket['temp_c'], 0.001);    // (50+52)/2
+    }
+
+    public function test_unknown_device_is_404(): void
+    {
+        $this->getJson('/api/devices/999999/metric-samples')->assertNotFound();
+    }
+
+    public function test_validates_bad_dates(): void
+    {
+        $device = Device::factory()->create();
+        $this->getJson("/api/devices/{$device->id}/metric-samples?from=not-a-date")
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['from']);
+    }
+
+    public function test_exposes_latest_metrics_on_the_device_resource(): void
+    {
+        Device::factory()->create(['cpu_pct' => 12.5, 'mem_used_pct' => 44.25, 'temp_c' => 39.5]);
+
+        $this->getJson('/api/devices')
+            ->assertOk()
+            ->assertJsonPath('data.0.cpu_pct', 12.5)
+            ->assertJsonPath('data.0.mem_used_pct', 44.25)
+            ->assertJsonPath('data.0.temp_c', 39.5);
+    }
+}

--- a/tests/Feature/LinkApiTest.php
+++ b/tests/Feature/LinkApiTest.php
@@ -250,6 +250,41 @@ class LinkApiTest extends TestCase
         $this->assertDatabaseMissing('links', ['id' => $link->id]);
     }
 
+    public function test_creates_a_one_ended_link_to_a_ping_only_device(): void
+    {
+        // A ping-only device (poll_method=none) has no interfaces - it links from the
+        // real end only, so b_interface_id is null and the link speed comes from A.
+        [$a, $b, $aIf] = $this->twoLinkableDevices();
+        $b->update(['poll_method' => 'none']);
+
+        $this->postJson('/api/links', [
+            'a_device_id' => $a->id, 'a_interface_id' => $aIf->id,
+            'b_device_id' => $b->id, 'b_interface_id' => null,
+        ])
+            ->assertCreated()
+            ->assertJsonPath('data.a_interface_id', $aIf->id)
+            ->assertJsonPath('data.b_interface_id', null)
+            ->assertJsonPath('data.b_interface', null)
+            ->assertJsonPath('data.eff_ab_mbps', 1000); // derived from the single (A) end
+
+        $this->assertDatabaseHas('links', ['a_interface_id' => $aIf->id, 'b_interface_id' => null]);
+    }
+
+    public function test_rejects_a_duplicate_one_ended_link_in_either_direction(): void
+    {
+        [$a, $b, $aIf] = $this->twoLinkableDevices();
+        $b->update(['poll_method' => 'none']);
+        Link::create(['a_device_id' => $a->id, 'a_interface_id' => $aIf->id, 'b_device_id' => $b->id, 'b_interface_id' => null]);
+
+        // Same devices + the same null end, reversed - a duplicate, not a second link.
+        $this->postJson('/api/links', [
+            'a_device_id' => $b->id, 'a_interface_id' => null,
+            'b_device_id' => $a->id, 'b_interface_id' => $aIf->id,
+        ])->assertStatus(422)->assertJsonValidationErrors(['a_interface_id']);
+
+        $this->assertSame(1, Link::count());
+    }
+
     public function test_lists_a_devices_interfaces_for_the_binder(): void
     {
         $device = Device::factory()->create();

--- a/tests/Feature/PollDeviceMetricsTest.php
+++ b/tests/Feature/PollDeviceMetricsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\Polling\PollDeviceMetrics;
+use App\Enums\PollMethod;
+use App\Events\DeviceMetricsUpdated;
+use App\Models\Device;
+use App\Services\Polling\DeviceMetrics;
+use App\Services\Polling\DeviceMetricsDriver;
+use App\Services\Polling\DeviceMetricsDriverFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class PollDeviceMetricsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Fake factory: returns cpu=12/mem=34/temp=56 for every device, EXCEPT a device
+     * named "BAD" (throws - failure-isolation probe) and "EMPTY" (all-null reading).
+     */
+    private function bindFakeDriver(): void
+    {
+        $driver = new class implements DeviceMetricsDriver
+        {
+            public function sample(Device $device): DeviceMetrics
+            {
+                if ($device->name === 'BAD') {
+                    throw new \RuntimeException('snmp boom');
+                }
+                if ($device->name === 'EMPTY') {
+                    return new DeviceMetrics;
+                }
+
+                return new DeviceMetrics(cpuPct: 12.0, memUsedPct: 34.0, tempC: 56.0);
+            }
+        };
+
+        $factory = new class($driver) extends DeviceMetricsDriverFactory
+        {
+            public function __construct(private DeviceMetricsDriver $driver) {}
+
+            public function for(Device $device): DeviceMetricsDriver
+            {
+                return $this->driver;
+            }
+        };
+
+        $this->app->instance(DeviceMetricsDriverFactory::class, $factory);
+    }
+
+    private function device(string $name): Device
+    {
+        return Device::factory()->create(['poll_method' => PollMethod::Snmp, 'name' => $name]);
+    }
+
+    public function test_writes_latest_values_history_and_broadcasts(): void
+    {
+        Event::fake([DeviceMetricsUpdated::class]);
+        $this->bindFakeDriver();
+        $device = $this->device('rtr1');
+
+        $count = app(PollDeviceMetrics::class)([$device->id]);
+
+        $this->assertSame(1, $count);
+        $device->refresh();
+        $this->assertSame(12.0, $device->cpu_pct);
+        $this->assertSame(34.0, $device->mem_used_pct);
+        $this->assertSame(56.0, $device->temp_c);
+        $this->assertNotNull($device->metrics_at);
+
+        $this->assertSame(1, DB::table('device_metric_samples')->where('device_id', $device->id)->count());
+        Event::assertDispatched(DeviceMetricsUpdated::class, fn ($e) => $e->devices[0]['device_id'] === $device->id
+            && $e->devices[0]['cpu_pct'] === 12.0);
+    }
+
+    public function test_one_failing_device_does_not_sink_the_batch(): void
+    {
+        Event::fake([DeviceMetricsUpdated::class]);
+        $this->bindFakeDriver();
+        $bad = $this->device('BAD');
+        $good = $this->device('good');
+
+        $count = app(PollDeviceMetrics::class)([$bad->id, $good->id]);
+
+        $this->assertSame(1, $count); // only the good one produced a reading
+        $this->assertNull($bad->refresh()->cpu_pct);
+        $this->assertSame(12.0, $good->refresh()->cpu_pct);
+    }
+
+    public function test_all_null_reading_is_skipped_no_history_no_stamp(): void
+    {
+        Event::fake([DeviceMetricsUpdated::class]);
+        $this->bindFakeDriver();
+        $device = $this->device('EMPTY');
+
+        $count = app(PollDeviceMetrics::class)([$device->id]);
+
+        $this->assertSame(0, $count);
+        $this->assertNull($device->refresh()->metrics_at);
+        $this->assertSame(0, DB::table('device_metric_samples')->count());
+        Event::assertNotDispatched(DeviceMetricsUpdated::class);
+    }
+}

--- a/tests/Feature/PollDispatcherTest.php
+++ b/tests/Feature/PollDispatcherTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Enums\PollMethod;
+use App\Jobs\PollDeviceMetricsBatchJob;
 use App\Jobs\PollInterfacesBatchJob;
 use App\Models\Device;
 use App\Services\Polling\PollDispatcher;
@@ -13,6 +14,29 @@ use Tests\TestCase;
 class PollDispatcherTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_metrics_dispatch_shards_pollable_devices_onto_the_poll_queue(): void
+    {
+        config(['mymate.poll.shards' => 4]);
+        Queue::fake();
+
+        $ids = Device::factory()->count(9)->create(['poll_method' => PollMethod::Snmp])->pluck('id')
+            ->merge(Device::factory()->count(3)->create(['poll_method' => PollMethod::RouterOs])->pluck('id'))
+            ->sort()->values()->all();
+        // Ping-only devices have no metrics driver - never dispatched.
+        Device::factory()->count(2)->create(['poll_method' => PollMethod::None]);
+
+        $shardsUsed = app(PollDispatcher::class)->dispatchMetrics();
+
+        $jobs = Queue::pushed(PollDeviceMetricsBatchJob::class);
+        $this->assertCount($shardsUsed, $jobs);
+
+        $dispatchedIds = $jobs->flatMap(fn (PollDeviceMetricsBatchJob $j) => $j->deviceIds)->sort()->values()->all();
+        $this->assertSame($ids, $dispatchedIds);
+        foreach ($jobs as $job) {
+            $this->assertSame('poll', $job->queue);
+        }
+    }
 
     public function test_shards_pollable_devices_into_batch_jobs_covering_each_once(): void
     {

--- a/tests/Feature/ProvisionSshKeyTest.php
+++ b/tests/Feature/ProvisionSshKeyTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Credential;
+use App\Models\Device;
+use App\Enums\PollMethod;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ProvisionSshKeyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('mymate.backup.url', 'http://127.0.0.1:8410');
+        config()->set('mymate.backup.token', 'test-token');
+    }
+
+    private function mikrotik(): Device
+    {
+        $cred = Credential::factory()->routeros()->create(['username' => 'nms', 'password' => 'pw']);
+
+        return Device::factory()->create([
+            'name' => 'CPE1', 'poll_method' => PollMethod::RouterOs, 'credential_id' => $cred->id,
+        ]);
+    }
+
+    public function test_provisions_a_key_and_stores_it_as_the_ssh_credential(): void
+    {
+        $this->actingAsUser();
+        Http::fake([
+            '*/api/provision/mikrotik-ssh-key' => Http::response([
+                'user' => 'nms', 'private_key' => "-----BEGIN OPENSSH PRIVATE KEY-----\nABC\n-----END OPENSSH PRIVATE KEY-----\n",
+                'ssh_port' => 22, 'ssh_enabled' => true, 'ssh_enabled_by' => true,
+            ], 200),
+        ]);
+        $device = $this->mikrotik();
+
+        $this->postJson("/api/devices/{$device->id}/provision-ssh-key")
+            ->assertOk()
+            ->assertJsonPath('ssh_enabled', true)
+            ->assertJsonPath('ssh_enabled_by', true);
+
+        $device->refresh();
+        $this->assertNotNull($device->ssh_credential_id);
+        $this->assertSame('mikrotik_routeros', $device->backup_driver); // switched to SSH backups
+
+        $ssh = Credential::find($device->ssh_credential_id);
+        $this->assertSame('ssh', $ssh->type);
+        $this->assertSame('nms+ct', $ssh->username);          // RouterOS clean-output suffix
+        $this->assertStringContainsString('PRIVATE KEY', $ssh->private_key);
+
+        // My Mate sent the device's API login to Rusted's provision endpoint.
+        Http::assertSent(fn ($r) => str_contains($r->url(), '/api/provision/mikrotik-ssh-key')
+            && $r['host'] === $device->mgmt_ip && $r['username'] === 'nms');
+    }
+
+    public function test_rejects_a_device_without_a_routeros_credential(): void
+    {
+        $this->actingAsUser();
+        $device = Device::factory()->create(['poll_method' => PollMethod::Snmp]);
+
+        $this->postJson("/api/devices/{$device->id}/provision-ssh-key")
+            ->assertStatus(422);
+    }
+}

--- a/tests/Feature/RunDeviceBackupTest.php
+++ b/tests/Feature/RunDeviceBackupTest.php
@@ -110,6 +110,27 @@ class RunDeviceBackupTest extends TestCase
             && ($req['username'] ?? null) === 'sshuser');
     }
 
+    public function test_the_api_driver_registers_with_the_routeros_transport(): void
+    {
+        Http::fake(['*' => Http::response(['status' => 'ok'], 200)]);
+
+        $cred = Credential::factory()->routeros()->create();
+        $device = Device::factory()->create([
+            'poll_method' => PollMethod::RouterOs,
+            'credential_id' => $cred->id,
+            'backup_enabled' => true,
+            'backup_driver' => 'mikrotik_routeros_api',
+        ]);
+
+        app(RunDeviceBackup::class)($device);
+
+        // The device pushed to Rusted must pin the API transport + its default port.
+        Http::assertSent(fn ($req) => str_contains($req->url(), '/api/devices')
+            && ($req['transport'] ?? null) === 'routeros-api'
+            && ($req['port'] ?? null) === 8728
+            && ($req['driver'] ?? null) === 'mikrotik_routeros_api');
+    }
+
     public function test_missing_credential_and_no_fallback_fails_cleanly(): void
     {
         Http::fake(['*' => Http::response(['status' => 'ok'], 200)]);

--- a/tests/Feature/RunDeviceBackupTest.php
+++ b/tests/Feature/RunDeviceBackupTest.php
@@ -110,27 +110,6 @@ class RunDeviceBackupTest extends TestCase
             && ($req['username'] ?? null) === 'sshuser');
     }
 
-    public function test_the_api_driver_registers_with_the_routeros_transport(): void
-    {
-        Http::fake(['*' => Http::response(['status' => 'ok'], 200)]);
-
-        $cred = Credential::factory()->routeros()->create();
-        $device = Device::factory()->create([
-            'poll_method' => PollMethod::RouterOs,
-            'credential_id' => $cred->id,
-            'backup_enabled' => true,
-            'backup_driver' => 'mikrotik_routeros_api',
-        ]);
-
-        app(RunDeviceBackup::class)($device);
-
-        // The device pushed to Rusted must pin the API transport + its default port.
-        Http::assertSent(fn ($req) => str_contains($req->url(), '/api/devices')
-            && ($req['transport'] ?? null) === 'routeros-api'
-            && ($req['port'] ?? null) === 8728
-            && ($req['driver'] ?? null) === 'mikrotik_routeros_api');
-    }
-
     public function test_missing_credential_and_no_fallback_fails_cleanly(): void
     {
         Http::fake(['*' => Http::response(['status' => 'ok'], 200)]);

--- a/tests/Feature/RunDeviceBackupTest.php
+++ b/tests/Feature/RunDeviceBackupTest.php
@@ -88,6 +88,28 @@ class RunDeviceBackupTest extends TestCase
         $this->assertNotNull($device->backup_message);
     }
 
+    public function test_a_dedicated_ssh_credential_is_preferred_over_the_poll_credential(): void
+    {
+        Http::fake(['*' => Http::response(['status' => 'ok'], 200)]);
+
+        $poll = Credential::factory()->routeros()->create(['username' => 'polluser']);
+        $ssh = Credential::factory()->ssh()->create(['username' => 'sshuser', 'password' => 'sshpass']);
+        $device = Device::factory()->create([
+            'poll_method' => PollMethod::RouterOs,
+            'credential_id' => $poll->id,
+            'ssh_credential_id' => $ssh->id,
+            'backup_enabled' => true,
+            'backup_driver' => 'mikrotik_routeros',
+        ]);
+
+        app(RunDeviceBackup::class)($device);
+
+        // The credential Rusted is told to use must be the SSH one, not the poll one.
+        Http::assertSent(fn ($req) => str_contains($req->url(), '/api/credentials')
+            && ($req['name'] ?? null) === "mymate-cred-{$ssh->id}"
+            && ($req['username'] ?? null) === 'sshuser');
+    }
+
     public function test_missing_credential_and_no_fallback_fails_cleanly(): void
     {
         Http::fake(['*' => Http::response(['status' => 'ok'], 200)]);

--- a/tests/Feature/SnmpDeviceMetricsDriverTest.php
+++ b/tests/Feature/SnmpDeviceMetricsDriverTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\PollMethod;
+use App\Models\Credential;
+use App\Models\Device;
+use App\Services\Polling\DeviceMetricProfiles;
+use App\Services\Polling\SnmpDeviceMetricsDriver;
+use App\Services\Snmp\SnmpClientException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\FakeSnmpClient;
+use Tests\TestCase;
+
+class SnmpDeviceMetricsDriverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function device(string $vendor = 'MikroTik', string $community = 'public-test'): Device
+    {
+        $credential = Credential::factory()->create(['snmp_community' => $community]);
+
+        return Device::factory()->create([
+            'poll_method' => PollMethod::Snmp,
+            'credential_id' => $credential->id,
+            'vendor' => $vendor,
+        ]);
+    }
+
+    private function driver(FakeSnmpClient $snmp): SnmpDeviceMetricsDriver
+    {
+        return new SnmpDeviceMetricsDriver($snmp, new DeviceMetricProfiles);
+    }
+
+    public function test_reads_cpu_memory_and_temperature_for_a_mikrotik(): void
+    {
+        $hr = config('mymate.device_metrics.hrstorage');
+        $snmp = new FakeSnmpClient;
+        // CPU = average hrProcessorLoad across cores.
+        $snmp->walks['.1.3.6.1.2.1.25.3.3.1.2'] = [1 => '10', 2 => '30'];
+        // Memory = the physical-RAM storage row: 250 / 1000 = 25%. Swap row is ignored.
+        $snmp->walks[$hr['descr']] = [1 => 'main memory', 2 => 'swap space'];
+        $snmp->walks[$hr['size']] = [1 => '1000', 2 => '2000'];
+        $snmp->walks[$hr['used']] = [1 => '250', 2 => '100'];
+        // Temperature via the MikroTik scalar OID (the fake returns this map for any GET).
+        $snmp->getsByCommunity['public-test'] = ['.1.3.6.1.4.1.14988.1.1.3.11.0' => '45'];
+
+        $m = $this->driver($snmp)->sample($this->device());
+
+        $this->assertSame(20.0, $m->cpuPct);
+        $this->assertSame(25.0, $m->memUsedPct);
+        $this->assertSame(45.0, $m->tempC);
+    }
+
+    public function test_unreadable_metrics_come_back_null_not_zero(): void
+    {
+        // Nothing scripted - walks return [], GET returns []. Every metric is null.
+        $m = $this->driver(new FakeSnmpClient)->sample($this->device('Linux'));
+
+        $this->assertNull($m->cpuPct);
+        $this->assertNull($m->memUsedPct);
+        $this->assertNull($m->tempC);
+        $this->assertTrue($m->isEmpty());
+    }
+
+    public function test_default_profile_has_no_temperature_oid(): void
+    {
+        $hr = config('mymate.device_metrics.hrstorage');
+        $snmp = new FakeSnmpClient;
+        $snmp->walks['.1.3.6.1.2.1.25.3.3.1.2'] = [1 => '50'];
+        $snmp->walks[$hr['descr']] = [1 => 'Physical memory'];
+        $snmp->walks[$hr['size']] = [1 => '800'];
+        $snmp->walks[$hr['used']] = [1 => '400'];
+        // A temp value is present, but an unknown vendor uses the default profile which
+        // declares no temp OID, so temperature stays null.
+        $snmp->getsByCommunity['public-test'] = ['.1.3.6.1.4.1.14988.1.1.3.11.0' => '45'];
+
+        $m = $this->driver($snmp)->sample($this->device('Acme'));
+
+        $this->assertSame(50.0, $m->cpuPct);
+        $this->assertSame(50.0, $m->memUsedPct);
+        $this->assertNull($m->tempC);
+    }
+
+    public function test_clamps_a_bogus_cpu_reading_into_range(): void
+    {
+        $snmp = new FakeSnmpClient;
+        $snmp->walks['.1.3.6.1.2.1.25.3.3.1.2'] = [1 => '250']; // impossible >100
+
+        $this->assertSame(100.0, $this->driver($snmp)->sample($this->device())->cpuPct);
+    }
+
+    public function test_throws_when_the_device_has_no_snmp_community(): void
+    {
+        $device = Device::factory()->create(['poll_method' => PollMethod::Snmp, 'vendor' => 'MikroTik']);
+
+        $this->expectException(SnmpClientException::class);
+        $this->driver(new FakeSnmpClient)->sample($device);
+    }
+}

--- a/tests/Feature/UpgradePreflightTest.php
+++ b/tests/Feature/UpgradePreflightTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\Devices\UpgradePreflight;
+use App\Enums\PollMethod;
+use App\Jobs\BulkUpgradeJob;
+use App\Models\Credential;
+use App\Models\Device;
+use App\Models\Link;
+use App\Support\DeviceHierarchy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class UpgradePreflightTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Credential $cred;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cred = Credential::factory()->routeros()->create();
+    }
+
+    private function device(string $name, ?int $parentId = null): Device
+    {
+        return Device::factory()->create([
+            'name' => $name,
+            'parent_device_id' => $parentId,
+            'poll_method' => PollMethod::RouterOs,
+            'credential_id' => $this->cred->id,
+            'os_version' => '7.20.7',
+            'latest_version' => '7.20.8',
+        ]);
+    }
+
+    private function preflight(): UpgradePreflight
+    {
+        return new UpgradePreflight(new DeviceHierarchy);
+    }
+
+    public function test_default_order_is_furthest_downstream_first_with_depth(): void
+    {
+        $core = $this->device('core');
+        $dist = $this->device('dist', $core->id);
+        $leaf = $this->device('leaf', $dist->id);
+
+        // Selection in arbitrary order -> ordered leaf, dist, core (deepest first).
+        $result = ($this->preflight())([$core->id, $leaf->id, $dist->id]);
+
+        $this->assertSame([$leaf->id, $dist->id, $core->id], $result['order']);
+        $this->assertSame(2, $result['plan'][0]['depth']); // leaf is 2 hops from root
+        $this->assertSame('dist', $result['plan'][0]['parent_name']); // leaf's parent is dist
+    }
+
+    public function test_preserve_order_keeps_the_given_sequence(): void
+    {
+        $core = $this->device('core');
+        $dist = $this->device('dist', $core->id);
+        $leaf = $this->device('leaf', $dist->id);
+
+        // Operator's hand-picked order (core first) must be kept verbatim.
+        $result = ($this->preflight())([$core->id, $dist->id, $leaf->id], preserveOrder: true);
+
+        $this->assertSame([$core->id, $dist->id, $leaf->id], $result['order']);
+    }
+
+    public function test_enriches_rows_with_linked_neighbours(): void
+    {
+        $a = $this->device('rtr-a');
+        $b = $this->device('rtr-b');
+        // A link between them (interface ends null - the neighbour list only needs devices).
+        Link::create(['a_device_id' => $a->id, 'a_interface_id' => null, 'b_device_id' => $b->id, 'b_interface_id' => null]);
+
+        $result = ($this->preflight())([$a->id, $b->id]);
+        $rowA = collect($result['plan'])->firstWhere('device_id', $a->id);
+
+        $this->assertSame(['rtr-b'], $rowA['neighbours']);
+    }
+
+    public function test_endpoint_with_explicit_order_dispatches_a_bulk_job_that_preserves_order(): void
+    {
+        $this->actingAsUser();
+        Queue::fake();
+        $core = $this->device('core');
+        $leaf = $this->device('leaf', $core->id);
+
+        $this->postJson('/api/devices/upgrade', [
+            'device_ids' => [$core->id, $leaf->id], // core first (operator's manual order)
+            'ordered' => true,
+            'explicit_order' => true,
+        ])->assertAccepted();
+
+        Queue::assertPushed(BulkUpgradeJob::class, fn (BulkUpgradeJob $j) => $j->preserveOrder === true
+            && $j->deviceIds === [$core->id, $leaf->id]);
+    }
+}


### PR DESCRIPTION
Closes #1.

Batch of fixes and a couple of new features from the user reports.

Fixes
- Add-device form let you pick SNMP but never a credential, so devices got created with no community and interface discovery failed with "no SNMP community". Added a credential picker to the form and the inspector so existing devices can be fixed without recreating them.
- Fixed mangled apostrophes that showed a literal backslash in a few dialogs (delete device, alert policies, discovery, link binder).
- You can now link a ping-only device from the other end. It has no interfaces so the link binds to the device and takes throughput from the end that does have one. Migration makes the interface ends nullable and relaxes the belongs-to trigger.

Device metrics
- Collect cpu / memory / temperature per device. SNMP uses per-vendor OID profiles (mikrotik, cisco, host-resources MIB fallback), RouterOS uses /system/resource and /system/health. Latest values on the device row, history in a partitioned table like the interface samples.
- Map tiles have a chip you click to switch between load / cpu / mem / temp, and the inspector shows current values plus sparklines.

Rolling upgrades
- New Upgrades page. Pick RouterOS devices, it orders them furthest-out first, shows parent and linked neighbours per row so you can eyeball the order, reorder by hand, then run them one at a time waiting for each to come back online before the next. Built on the existing ordered-upgrade engine; the run now honours the exact order you set.

Tests: 405 backend tests pass, tsc clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/athenanetworks/mymate/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->