### PR TITLE
Ping flap dampening: require N consecutive misses before marking a device down

### DIFF
--- a/app/Actions/Polling/PingFleet.php
+++ b/app/Actions/Polling/PingFleet.php
@@ -41,17 +41,41 @@ class PingFleet
         /** @var array<string, PingSample> $samples */
         $samples = $this->pinger->measure($devices->pluck('mgmt_ip')->all());
 
+        // Flap dampening: a device only flips to `down` after `fail_threshold` consecutive
+        // missed sweeps, so a single dropped reply (transient loss, a busy sweep) doesn't alarm.
+        // Recovery is immediate - one reply resets the streak and marks it up.
+        $threshold = max(1, (int) config('mymate.ping.fail_threshold', 3));
+
         $changed = 0;
         foreach ($devices as $device) {
-            $new = ($samples[$device->mgmt_ip] ?? null)?->reachable ? DeviceStatus::Up : DeviceStatus::Down;
+            $reachable = ($samples[$device->mgmt_ip] ?? null)?->reachable ?? false;
 
-            if ($device->status !== $new) {
-                $device->status = $new;
+            $streak = (int) $device->fail_streak;
+            if ($reachable) {
+                $newStreak = 0;
+                $newStatus = DeviceStatus::Up;
+            } else {
+                $newStreak = min($streak + 1, $threshold); // cap so a long-down device isn't rewritten
+                // Hold the current status until we've missed `threshold` sweeps in a row.
+                $newStatus = $newStreak >= $threshold ? DeviceStatus::Down : $device->status;
+            }
+
+            $streakChanged = $newStreak !== $streak;
+            $statusChanged = $device->status !== $newStatus;
+            if (! $streakChanged && ! $statusChanged) {
+                continue;
+            }
+
+            $device->fail_streak = $newStreak;
+            if ($statusChanged) {
+                $device->status = $newStatus;
                 $device->last_change = now();
-                $device->save();
+            }
+            $device->save();
 
+            if ($statusChanged) {
                 // Log the outage window: open on down, close on recovery.
-                $new === DeviceStatus::Down ? $this->outages->open($device) : $this->outages->close($device);
+                $newStatus === DeviceStatus::Down ? $this->outages->open($device) : $this->outages->close($device);
 
                 LiveBroadcast::send(new DeviceStatusChanged($device));
                 $changed++;

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -20,7 +20,7 @@ class Device extends Model
 
     protected $fillable = [
         'name', 'mgmt_ip', 'poll_method', 'credential_id', 'ssh_credential_id', 'routeros_credential_id', 'agent_id',
-        'status', 'monitored', 'last_change', 'map_x', 'map_y', 'latitude', 'longitude', 'geo_source',
+        'status', 'monitored', 'last_change', 'fail_streak', 'map_x', 'map_y', 'latitude', 'longitude', 'geo_source',
         'device_type', 'icon', 'icon_color', 'parent_device_id', 'vendor', 'model', 'serial', 'cpu', 'ram_bytes', 'arch', 'uptime_seconds', 'uptime_at',
         'os_version', 'latest_version', 'upgrade_status', 'upgrade_message', 'upgrade_at',
         'discovery_error', 'discovered_at',

--- a/config/mymate.php
+++ b/config/mymate.php
@@ -29,6 +29,11 @@ return [
         // columns. The up/down status flip still happens every sweep; only the trend write is
         // throttled to keep the fast sweep cheap.
         'history_interval' => (int) env('MYMATE_PING_HISTORY_INTERVAL', 60),
+        // Consecutive missed sweeps before a device flips to `down`. 1 = flip on the first miss
+        // (original behaviour). Higher tolerates transient packet loss - important at scale,
+        // where a device that drops one reply shouldn't alarm. Recovery is always immediate
+        // (one reply -> up). At the default 5s interval, 3 = ~15s of solid misses before down.
+        'fail_threshold' => max(1, (int) env('MYMATE_PING_FAIL_THRESHOLD', 3)),
     ],
 
     // Interface throughput loop. intervals in seconds.

--- a/database/migrations/2026_07_24_000001_add_fail_streak_to_devices.php
+++ b/database/migrations/2026_07_24_000001_add_fail_streak_to_devices.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Consecutive missed up/down sweeps for a device. The ping loop only flips a device to `down`
+ * after it has missed `mymate.ping.fail_threshold` sweeps in a row - a single dropped reply (a
+ * blip of packet loss, an over-busy sweep) no longer alarms. Recovery is still immediate: one
+ * reply resets the streak and marks it up. Capped at the threshold so a long-down device isn't
+ * written every sweep.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->unsignedSmallInteger('fail_streak')->default(0)->after('last_change');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('fail_streak');
+        });
+    }
+};

--- a/tests/Feature/PingFleetTest.php
+++ b/tests/Feature/PingFleetTest.php
@@ -17,6 +17,14 @@ class PingFleetTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Most cases exercise the flip on a single sweep; the dampening threshold has its own
+        // test below. Default it to 1 here so a single miss flips (the pre-dampening behaviour).
+        config(['mymate.ping.fail_threshold' => 1]);
+    }
+
     /** Bind a fake Pinger that reports only the given IPs as reachable. */
     private function fakePinger(array $reachable): void
     {
@@ -144,5 +152,36 @@ class PingFleetTest extends TestCase
         $this->assertSame('DeviceStatusChanged', $event->broadcastAs());
         $this->assertSame($device->id, $event->broadcastWith()['id']);
         $this->assertSame('up', $event->broadcastWith()['status']);
+    }
+
+    public function test_a_device_needs_repeated_misses_before_going_down(): void
+    {
+        config(['mymate.ping.fail_threshold' => 3]);
+        $device = Device::factory()->create(['mgmt_ip' => '10.0.0.1', 'status' => DeviceStatus::Up]);
+        $this->fakePinger([]); // unreachable every sweep
+
+        // First two misses: still up (streak building), no change reported.
+        $this->assertSame(0, app(PingFleet::class)());
+        $this->assertSame(DeviceStatus::Up, $device->refresh()->status);
+        $this->assertSame(1, $device->fail_streak);
+
+        $this->assertSame(0, app(PingFleet::class)());
+        $this->assertSame(DeviceStatus::Up, $device->refresh()->status);
+        $this->assertSame(2, $device->fail_streak);
+
+        // Third consecutive miss crosses the threshold -> down.
+        $this->assertSame(1, app(PingFleet::class)());
+        $this->assertSame(DeviceStatus::Down, $device->refresh()->status);
+    }
+
+    public function test_one_reply_recovers_immediately_and_resets_the_streak(): void
+    {
+        config(['mymate.ping.fail_threshold' => 3]);
+        $device = Device::factory()->create(['mgmt_ip' => '10.0.0.1', 'status' => DeviceStatus::Down, 'fail_streak' => 3]);
+        $this->fakePinger(['10.0.0.1']); // reachable again
+
+        $this->assertSame(1, app(PingFleet::class)());
+        $this->assertSame(DeviceStatus::Up, $device->refresh()->status);
+        $this->assertSame(0, $device->fail_streak);
     }
 }


### PR DESCRIPTION
## What

Add flap dampening to the up/down sweep: only mark a device `down` after N consecutive missed sweeps, instead of on the very first miss.

Flipping to `down` on a single missed sweep is untenable at scale. Transient packet loss (or an over-busy sweep) constantly produces false-downs — and, with status-change notifications, a wall of flap alarms — for devices that are actually fine.

## Changes

- New `fail_streak` column on `devices`, and a `mymate.ping.fail_threshold` config (`MYMATE_PING_FAIL_THRESHOLD`, default **3** ≈ 15s at a 5s interval).
- `PingFleet` increments a per-device streak on each miss and only flips to `down` once it reaches the threshold. Recovery stays **immediate** — one reply resets the streak and marks the device up. The streak is capped at the threshold so a long-down device isn't rewritten every sweep.
- Default `3` is a mild, sensible dampening; set it to `1` to keep the original flip-on-first-miss behaviour.

## Testing

`PingFleetTest` gains a case proving a device needs `fail_threshold` consecutive misses before going down, and one proving a single reply recovers immediately and resets the streak. Existing cases pin `fail_threshold = 1` to keep asserting the single-sweep flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
