### PR TITLE
build: make `npm run build` refuse to produce a blank SPA

### DIFF
--- a/deploy/build/vite-build.sh
+++ b/deploy/build/vite-build.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Guarded frontend build.
+#
+# WHY THIS EXISTS
+# ---------------
+# resources/js/lib/echo.ts reads import.meta.env.VITE_REVERB_APP_KEY. Vite only exposes
+# VITE_-prefixed variables, but .env names the key REVERB_APP_KEY. So a bare `vite build`
+# bakes `new Echo({ key: undefined })` into the bundle, Echo throws while the app is
+# mounting, and the SPA renders a BLANK PAGE — every asset returns 200 and nothing in the
+# console points at the cause. It is a genuinely nasty way to lose an install.
+#
+# deploy/build/build-deb.sh already sets the key, but `npm run build` (the obvious thing
+# to run by hand) did not, and that is how we shipped a blank page for ~16 hours.
+#
+# This wrapper makes the safe path the default: it sources the key, refuses to build
+# without one, and verifies the built bundle before declaring success.
+set -e
+
+cd "$(dirname "$0")/../.."
+
+if [ -z "$VITE_REVERB_APP_KEY" ] && [ -f .env ]; then
+    # \042 = double quote, \047 = single quote — octal keeps the sh quoting sane.
+    VITE_REVERB_APP_KEY=$(grep -E '^REVERB_APP_KEY=' .env | head -1 | cut -d= -f2- | tr -d '\042\047 \r')
+fi
+
+if [ -z "$VITE_REVERB_APP_KEY" ]; then
+    echo "ERROR: VITE_REVERB_APP_KEY is empty and REVERB_APP_KEY was not found in .env" >&2
+    echo "Refusing to build: the result would be a blank SPA (Echo key undefined)." >&2
+    echo "Set REVERB_APP_KEY in .env, or export VITE_REVERB_APP_KEY before building." >&2
+    exit 1
+fi
+export VITE_REVERB_APP_KEY
+
+echo "==> building with VITE_REVERB_APP_KEY=$VITE_REVERB_APP_KEY"
+npx vite build "$@"
+
+# Post-build guard: 'key:void 0' is the minified signature of the blank-screen bug.
+# Only meaningful for a default outDir; build-deb.sh passes --outDir and stages elsewhere.
+if ls public/build/assets/*.js >/dev/null 2>&1; then
+    if grep -ql 'key:void 0' public/build/assets/*.js 2>/dev/null; then
+        echo >&2
+        echo "ERROR: built bundle contains 'key:void 0' — this build WOULD render blank." >&2
+        echo "The Reverb key did not reach vite." >&2
+        exit 1
+    fi
+    echo "==> verified: Reverb key is baked into the bundle"
+else
+    echo "==> note: no bundle at public/build/assets — skipped the blank-screen check"
+fi
+
+# Installs run php-fpm/nginx as the service user while builds are often run as root over
+# ssh; leaving public/build root-owned is a foot-gun. Defaults to the packaged user.
+CHOWN_USER="${MYMATE_CHOWN_USER:-mymate}"
+if [ "$(id -u)" = "0" ] && id "$CHOWN_USER" >/dev/null 2>&1; then
+    chown -R "$CHOWN_USER:$CHOWN_USER" public/build 2>/dev/null || true
+    echo "==> public/build owned by $CHOWN_USER"
+fi

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "build": "vite build",
-        "dev": "vite"
+        "build": "sh deploy/build/vite-build.sh",
+        "dev": "vite",
+        "build:unsafe": "vite build"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",


### PR DESCRIPTION
We lost a production install to a blank page for ~16 hours and the cause turned out to be a footgun in `package.json`, so this makes the safe path the default.

## The problem

`resources/js/lib/echo.ts` reads `import.meta.env.VITE_REVERB_APP_KEY`. Vite only exposes `VITE_`-prefixed variables, but `.env` names the key `REVERB_APP_KEY`. So a bare `vite build` bakes:

```js
new Echo({ broadcaster: "reverb", key: void 0, ... })
```

Echo throws while the app is mounting, and the SPA renders a **blank page** — every asset returns 200, the shell loads, and nothing in the console points at the cause. It is a genuinely hard failure to diagnose from the symptom.

`deploy/build/build-deb.sh` already does this correctly (it passes `VITE_REVERB_APP_KEY="$REVERB_KEY"`), so packaged builds were never affected. But `npm run build` is the obvious command to run by hand when deploying from source, and it had no such guard. That is exactly how we shipped a blank page.

## The change

Routes `npm run build` through `deploy/build/vite-build.sh`, which:

1. Sources the key from `.env` when `VITE_REVERB_APP_KEY` is not already exported
2. **Refuses to build** if no key can be found, instead of silently baking `undefined`
3. Greps the built bundle for `key:void 0` — the minified signature of the bug — and fails the build if present
4. Chowns `public/build` to the service user when building as root (builds over ssh otherwise leave it root-owned)

The raw path stays available as `npm run build:unsafe`.

`build-deb.sh` is untouched and unaffected — it calls `npx vite build` directly with its own `--outDir`. The post-build check is skipped (with a printed note, not silently) when no bundle exists at the default path, so it does not interfere with staged builds.

Verified both directions: refuses with no key present and never invokes vite; flags a bundle containing `key:void 0`; passes a good bundle; and a plain `npm run build` on our box now produces a correct bundle and reports the key it used.