### PR TITLE
Tame the status-change notification firehose on large fleets

### DIFF
--- a/resources/js/features/shell/StatusCounts.tsx
+++ b/resources/js/features/shell/StatusCounts.tsx
@@ -16,8 +16,11 @@ const short: Record<DeviceStatus, string> = { up: 'up', down: 'down', unknown: '
 /** Live up/down/unknown tallies for the top bar, derived from the device snapshot. */
 export function StatusCounts() {
     const { data: devices } = useDevices();
+    // Count only monitored devices. A paused/acked device (monitored=false) is deliberately not
+    // being polled, so its stale status shouldn't inflate the up/down tallies - the pill reflects
+    // the health of what's actually watched.
     const counts: Record<DeviceStatus, number> = { up: 0, down: 0, unknown: 0 };
-    for (const d of devices ?? []) counts[d.status] += 1;
+    for (const d of devices ?? []) if (d.monitored) counts[d.status] += 1;
 
     return (
         <div className="flex items-center gap-1.5">

--- a/resources/js/features/topology/components/MapCanvas.tsx
+++ b/resources/js/features/topology/components/MapCanvas.tsx
@@ -182,12 +182,42 @@ export function MapCanvas() {
             return next;
         });
     }, []);
+    // Coalesce status-change toasts. A single flip still shows its own toast; a storm (large
+    // fleet, or many devices flapping at once) collapses into one "N down, M back online"
+    // summary per window instead of a firehose of individual toasts.
+    const statusBuf = useRef<{ up: number; down: number; n: number; lastName: string; lastStatus: DeviceStatus }>(
+        { up: 0, down: 0, n: 0, lastName: '', lastStatus: 'unknown' },
+    );
+    const statusFlush = useRef<ReturnType<typeof setTimeout> | null>(null);
     const handleStatus = useCallback((e: { name: string; status: DeviceStatus }) => {
-        pushToast({
-            title: `${e.name} is ${e.status}`,
-            detail: e.status === 'down' ? 'No longer responding to ping' : e.status === 'up' ? 'Back online' : undefined,
-            tone: e.status === 'up' ? 'up' : e.status === 'down' ? 'down' : 'info',
-        });
+        const b = statusBuf.current;
+        if (e.status === 'up') b.up++;
+        else if (e.status === 'down') b.down++;
+        b.n++;
+        b.lastName = e.name;
+        b.lastStatus = e.status;
+        if (statusFlush.current) return; // a flush is already scheduled; keep accumulating
+        statusFlush.current = setTimeout(() => {
+            const s = statusBuf.current;
+            if (s.n === 1) {
+                pushToast({
+                    title: `${s.lastName} is ${s.lastStatus}`,
+                    detail: s.lastStatus === 'down' ? 'No longer responding to ping' : s.lastStatus === 'up' ? 'Back online' : undefined,
+                    tone: s.lastStatus === 'up' ? 'up' : s.lastStatus === 'down' ? 'down' : 'info',
+                });
+            } else {
+                const parts: string[] = [];
+                if (s.down) parts.push(`${s.down} down`);
+                if (s.up) parts.push(`${s.up} back online`);
+                pushToast({
+                    title: parts.join(', '),
+                    detail: `${s.n} devices changed state`,
+                    tone: s.down >= s.up ? 'down' : 'up',
+                });
+            }
+            statusBuf.current = { up: 0, down: 0, n: 0, lastName: '', lastStatus: 'unknown' };
+            statusFlush.current = null;
+        }, 3000);
     }, []);
     useMapChannel(handleUtil, handleStatus);
 

--- a/resources/js/features/topology/hooks/useMapChannel.ts
+++ b/resources/js/features/topology/hooks/useMapChannel.ts
@@ -40,8 +40,10 @@ export function useMapChannel(
                     prev,
             );
 
-            // Notify only on a real flip (skip the first unknown->up settle if you prefer).
-            if (before && before.status !== e.status) {
+            // Notify only on a real up<->down flip. Skip the settle out of `unknown` (a fresh
+            // device, or the first sweep after a restart), which on a large fleet would fire a
+            // notification for every device at once.
+            if (before && before.status !== e.status && before.status !== 'unknown') {
                 onStatus?.({ id: e.id, name: before.name, status: e.status });
             }
         });


### PR DESCRIPTION
This is the **client-side** counterpart to 1a24d90 ("Broadcast live map updates inline so Redis can't OOM the box"). That commit stopped the broker from being overwhelmed; this stops the browser from being overwhelmed by the same storm. They are complementary — this touches only frontend files and does not change any broadcast semantics.

At a few hundred devices a toast per up/down flip is fine. At ~25,600 (our fleet) it is a wall of notifications, and the first sweep after a restart fires one for **every** device at once.

Three changes:

- **Skip the settle out of `unknown`.** A fresh device, or the first sweep after a restart, no longer notifies for the whole fleet — that transition carries no information.
- **Coalesce status toasts.** A lone flip still gets its own toast, so small deployments see no behaviour change. A storm collapses into a single `N down, M back online` summary per window.
- **Count only monitored devices** in `StatusCounts`, so a paused/acked device's stale status no longer inflates the up/down pill.

Files: `StatusCounts.tsx`, `MapCanvas.tsx`, `useMapChannel.ts` (+43/-8).

Entirely understandable if the coalescing window or thresholds should be configurable rather than fixed — happy to rework if you would prefer that shape.