### PR TITLE
snmp: treat SNMPv1 noSuchName as absence, not a poll failure

### DIFF
--- a/app/Services/Snmp/PhpSnmpClient.php
+++ b/app/Services/Snmp/PhpSnmpClient.php
@@ -98,7 +98,12 @@ class PhpSnmpClient implements SnmpClient
         return str_contains($e, 'no such object')
             || str_contains($e, 'no such instance')
             || str_contains($e, 'no more variables left') // "...past the end of the MIB tree"
-            || str_contains($e, 'end of mib');
+            || str_contains($e, 'end of mib')
+            // SNMPv1 has no noSuchObject/noSuchInstance exceptions - the agent reports an absent
+            // OID with the noSuchName error instead. Same meaning, so treat it the same way,
+            // otherwise one unsupported OID sinks the whole metric read on every v1-only device.
+            || str_contains($e, 'no such variable name')
+            || str_contains($e, 'nosuchname');
     }
 
     /**

--- a/tests/Unit/PhpSnmpClientTest.php
+++ b/tests/Unit/PhpSnmpClientTest.php
@@ -48,6 +48,11 @@ class PhpSnmpClientTest extends TestCase
         $this->assertTrue($isAbsence('No Such Instance currently exists at this OID'));
         $this->assertTrue($isAbsence('No more variables left in this MIB View (It is past the end of the MIB tree)'));
 
+        // SNMPv1 has no noSuchObject/noSuchInstance exceptions - it reports absence as noSuchName.
+        // v1-only agents (airOS and much other WISP CPE) only ever produce these phrasings.
+        $this->assertTrue($isAbsence("Error in packet at '.1.3.6.1.4.1.14988.1.1.1.3.1': No such variable name in this MIB."));
+        $this->assertTrue($isAbsence('noSuchName'));
+
         // Genuine failures - must propagate so the device is isolated.
         $this->assertFalse($isAbsence('No response from 10.0.0.1'));
         $this->assertFalse($isAbsence('Timeout'));


### PR DESCRIPTION
Two lines in `isAbsence()`, but it is the difference between "all my Ubiquiti gear has no metrics" and a working poll.

## The bug

SNMPv1 has no `noSuchObject` / `noSuchInstance` PDU exceptions — a v1 agent reports an absent OID with the **`noSuchName`** error instead. `isAbsence()` only recognises the v2c phrasings, so on a v1 agent a single unsupported OID throws instead of yielding empty, and that sinks the **entire** metric read: no CPU, no memory, no frequency, on every poll.

The existing comment already states the right intent — "a best-effort read should treat them as no value, not a failed poll" — this just extends it to the v1 phrasing.

## Why it matters more than it looks

This is not an edge case for WISP fleets. **airOS is v1-only** — v2c times out outright on those agents — so every Ubiquiti device reads as metric-less until this is handled. In our fleet that is ~12,200 devices. We found it because CPU/memory/frequency were blank fleet-wide for all airOS gear while the devices were plainly up and answering.

## Verification

Extended the existing `test_recognises_oid_absence_errors_but_not_transport_failures` rather than adding a new test, since it is exactly the case that test covers.

Confirmed red → green: the new assertions **fail** against unpatched `main` (`PhpSnmpClientTest.php:53`) and pass with the change. Full SNMP suites: 40 passed / 120 assertions.

Transport failures are untouched — `No response`, `Timeout`, and auth failures still propagate so the device is properly isolated. The existing assertions covering that still pass.