### PR TITLE
Geo map: sites folded into DeviceGeo, compact feeds, backhaul lines, Leaflet clustering + layer toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ of commit subjects.
 
 ## [Unreleased]
 
+### Added
+- **Sites: place a whole tower at once.** A site (tower, fiber cabinet, POP) carries coordinates
+  once and every device at it inherits them on the geo map, so a few thousand devices on a few
+  hundred towers no longer means dragging a few thousand pins. The site slots into the same
+  coordinate resolution as uplink inheritance: own pin, else site, else uplink ancestor. Sites
+  import from a plain CSV (`php artisan mymate:sites:import`) keyed on an `external_ref` from
+  whatever inventory owns the truth, so a scheduled re-sync corrects coordinates in place;
+  devices are placed either from an authoritative `mgmt_ip,external_ref` mapping or by snapping
+  unplaced devices to the nearest site, and neither pass ever overwrites a placement an operator
+  made by hand. Manage them at `/api/sites`, or assign one device from the device editor.
+- **Geo map: the whole fleet renders smoothly.** Device markers now cluster into count-bubbles
+  that split apart as you zoom, and the map has compact purpose-built feeds (`/geo/devices`,
+  `/geo/backhauls`) so plotting a dot no longer means pulling the full multi-megabyte device
+  payload.
+- **Geo map: backhaul lines.** Site-to-site links (imported alongside sites) draw as solid fiber /
+  dashed wireless lines under the markers, so the map shows the real backbone instead of leaving
+  you to infer it.
+- **Geo map: layer toggles.** Devices and backhauls each have a switch on the map, remembered
+  across reloads (both start on).
+
 ### Fixed
 - **Map: device up/down toasts no longer pile up.** Down toasts were sticky (meant for error
   messages), so a flapping device stacked a fresh "X is down" notification every cycle and the

--- a/app/Actions/Devices/UpdateDevice.php
+++ b/app/Actions/Devices/UpdateDevice.php
@@ -15,6 +15,12 @@ class UpdateDevice
             $data['geo_source'] = ($data['latitude'] ?? null) !== null && ($data['longitude'] ?? null) !== null ? 'manual' : null;
         }
 
+        // Assigning (or clearing) a site through the editor is a manual decision - stamp the
+        // source so an import or nearest-site pass never overrides the operator.
+        if (array_key_exists('site_id', $data)) {
+            $data['site_source'] = $data['site_id'] !== null ? 'manual' : null;
+        }
+
         $device->update($data);
 
         return $device;

--- a/app/Actions/Sites/AssignDevicesToSites.php
+++ b/app/Actions/Sites/AssignDevicesToSites.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Actions\Sites;
+
+use App\Models\Device;
+use App\Models\Site;
+use App\Support\CsvReader;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+/**
+ * Put devices at sites, by either of the two things an operator actually has.
+ *
+ * MAPPING (authoritative): a CSV of `mgmt_ip,external_ref` straight out of the OSS that
+ * already knows which tower each radio is on. This is the accurate path - the OSS was told
+ * the truth by whoever installed the gear.
+ *
+ * NEAREST (derived): for devices that carry their own coordinates (a pin someone dropped, or
+ * an SNMP sysLocation the poller parsed) but no site, snap to the closest site inside a
+ * radius. Useful for filling gaps, but it is a guess: a backhaul radio at a tower half a mile
+ * from a subscriber can land at the wrong one, so the radius defaults tight and anything
+ * outside it is left unassigned rather than forced.
+ *
+ * Both passes skip `site_source = manual`, so an operator's own placement is never
+ * overwritten by a re-run.
+ */
+class AssignDevicesToSites
+{
+    /** Default snap radius for the nearest-site pass, in kilometres. */
+    public const DEFAULT_RADIUS_KM = 0.5;
+
+    /**
+     * Assign from an authoritative `mgmt_ip,external_ref` CSV.
+     *
+     * @return array{assigned: int, unmatched_ip: int, unknown_site: int, skipped_manual: int}
+     */
+    public function fromMapping(string $csvPath): array
+    {
+        if (! is_file($csvPath)) {
+            throw new RuntimeException("Mapping CSV not found: {$csvPath}");
+        }
+
+        // Both sides in memory: a fleet's devices and sites are thousands of rows, not
+        // millions, and this turns the whole pass into one query each plus one update per hit.
+        $devicesByIp = Device::query()->get(['id', 'mgmt_ip', 'site_source'])->keyBy('mgmt_ip');
+        $siteIdByRef = Site::query()->whereNotNull('external_ref')->pluck('id', 'external_ref');
+
+        $summary = ['assigned' => 0, 'unmatched_ip' => 0, 'unknown_site' => 0, 'skipped_manual' => 0];
+
+        DB::transaction(function () use ($csvPath, $devicesByIp, $siteIdByRef, &$summary): void {
+            foreach (CsvReader::rows($csvPath) as $row) {
+                $ip = trim((string) ($row['mgmt_ip'] ?? ''));
+                $ref = trim((string) ($row['external_ref'] ?? ''));
+                if ($ip === '' || $ref === '') {
+                    continue;
+                }
+
+                $device = $devicesByIp->get($ip);
+                if ($device === null) {
+                    $summary['unmatched_ip']++;
+
+                    continue;
+                }
+                if ($device->site_source === 'manual') {
+                    $summary['skipped_manual']++;
+
+                    continue;
+                }
+
+                $siteId = $siteIdByRef->get($ref);
+                if ($siteId === null) {
+                    $summary['unknown_site']++;
+
+                    continue;
+                }
+
+                Device::whereKey($device->id)->update(['site_id' => $siteId, 'site_source' => 'import']);
+                $summary['assigned']++;
+            }
+        });
+
+        return $summary;
+    }
+
+    /**
+     * Snap unassigned devices that have their own coordinates to the nearest site.
+     *
+     * @param  float  $radiusKm  devices with no site inside this radius are left unassigned
+     * @return array{assigned: int, too_far: int, considered: int}
+     */
+    public function byNearest(float $radiusKm = self::DEFAULT_RADIUS_KM): array
+    {
+        $sites = Site::query()
+            ->whereNotNull('latitude')->whereNotNull('longitude')
+            ->get(['id', 'latitude', 'longitude']);
+
+        $summary = ['assigned' => 0, 'too_far' => 0, 'considered' => 0];
+        if ($sites->isEmpty()) {
+            return $summary;
+        }
+
+        Device::query()
+            ->whereNull('site_id')
+            ->whereNotNull('latitude')->whereNotNull('longitude')
+            ->where(fn ($q) => $q->whereNull('site_source')->orWhere('site_source', '!=', 'manual'))
+            ->chunkById(500, function ($devices) use ($sites, $radiusKm, &$summary): void {
+                foreach ($devices as $device) {
+                    $summary['considered']++;
+
+                    $best = null;
+                    $bestKm = INF;
+                    foreach ($sites as $site) {
+                        $km = $site->distanceKmTo($device->latitude, $device->longitude);
+                        if ($km !== null && $km < $bestKm) {
+                            $bestKm = $km;
+                            $best = $site;
+                        }
+                    }
+
+                    if ($best === null || $bestKm > $radiusKm) {
+                        $summary['too_far']++;
+
+                        continue;
+                    }
+
+                    Device::whereKey($device->id)->update(['site_id' => $best->id, 'site_source' => 'nearest']);
+                    $summary['assigned']++;
+                }
+            });
+
+        return $summary;
+    }
+}

--- a/app/Actions/Sites/ImportSiteLinks.php
+++ b/app/Actions/Sites/ImportSiteLinks.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Actions\Sites;
+
+use App\Models\Site;
+use App\Models\SiteLink;
+use App\Support\CsvReader;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+/**
+ * Upsert backhaul links between sites from a CSV out of the OSS that owns the backbone topology.
+ * Columns: site_a_ref, site_b_ref (both the sites' external_ref, i.e. the OSS id), optional
+ * media_type. Idempotent on a stable external_ref built from the pair, so re-running against
+ * the source is a safe re-sync.
+ */
+class ImportSiteLinks
+{
+    /**
+     * @return array{created: int, updated: int, skipped: int}
+     */
+    public function __invoke(string $csvPath): array
+    {
+        if (! is_file($csvPath)) {
+            throw new RuntimeException("Site-links CSV not found: {$csvPath}");
+        }
+
+        $siteIdByRef = Site::query()->whereNotNull('external_ref')->pluck('id', 'external_ref');
+        $summary = ['created' => 0, 'updated' => 0, 'skipped' => 0];
+
+        DB::transaction(function () use ($csvPath, $siteIdByRef, &$summary): void {
+            foreach (CsvReader::rows($csvPath) as $row) {
+                $aRef = trim((string) ($row['site_a_ref'] ?? ''));
+                $bRef = trim((string) ($row['site_b_ref'] ?? ''));
+                $a = $siteIdByRef->get($aRef);
+                $b = $siteIdByRef->get($bRef);
+                // Both ends must resolve to a known site, and a link to itself is meaningless.
+                if ($a === null || $b === null || $a === $b) {
+                    $summary['skipped']++;
+
+                    continue;
+                }
+
+                // Order-independent key so A-B and B-A are the same link.
+                $ref = 'pair:'.min($a, $b).'-'.max($a, $b);
+                $link = SiteLink::firstOrNew(['external_ref' => $ref]);
+                $existed = $link->exists;
+                $link->site_a_id = $a;
+                $link->site_b_id = $b;
+                $link->media_type = ($m = trim((string) ($row['media_type'] ?? ''))) !== '' ? $m : null;
+                $link->save();
+
+                $summary[$existed ? 'updated' : 'created']++;
+            }
+        });
+
+        return $summary;
+    }
+}

--- a/app/Actions/Sites/ImportSites.php
+++ b/app/Actions/Sites/ImportSites.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Actions\Sites;
+
+use App\Enums\SiteKind;
+use App\Models\Site;
+use App\Support\CsvReader;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+/**
+ * Upsert sites from a CSV export of whatever system owns the truth (an OSS/inventory, a NetBox
+ * dump, a spreadsheet).
+ *
+ * Deliberately a plain CSV rather than an integration with any one OSS: every operator has a
+ * different inventory, and a re-runnable "here are my sites" file is the one thing they can
+ * all produce. `external_ref` is the upsert key, so this is safe to run on a schedule - a
+ * corrected coordinate in the source flows through on the next run and every device at the
+ * site follows it, because devices inherit rather than copy.
+ *
+ * Required columns: name. Optional: external_ref, kind, latitude, longitude, address, note.
+ * A row with no external_ref is matched on name instead, so a hand-written file works too.
+ */
+class ImportSites
+{
+    /**
+     * @return array{created: int, updated: int, skipped: int}
+     */
+    public function __invoke(string $csvPath): array
+    {
+        if (! is_file($csvPath)) {
+            throw new RuntimeException("Sites CSV not found: {$csvPath}");
+        }
+
+        $summary = ['created' => 0, 'updated' => 0, 'skipped' => 0];
+
+        DB::transaction(function () use ($csvPath, &$summary): void {
+            foreach (CsvReader::rows($csvPath) as $row) {
+                $name = trim((string) ($row['name'] ?? ''));
+                if ($name === '') {
+                    $summary['skipped']++;
+
+                    continue;
+                }
+
+                $ref = trim((string) ($row['external_ref'] ?? ''));
+                $site = $ref !== ''
+                    ? Site::firstOrNew(['external_ref' => $ref])
+                    : Site::firstOrNew(['name' => $name]);
+
+                $existed = $site->exists;
+
+                $site->name = $name;
+                $site->kind = SiteKind::parse($row['kind'] ?? null);
+                $site->latitude = $this->coord($row['latitude'] ?? null, 90);
+                $site->longitude = $this->coord($row['longitude'] ?? null, 180);
+                $site->address = $this->nullableString($row['address'] ?? null);
+                $site->note = $this->nullableString($row['note'] ?? null);
+                if ($ref !== '') {
+                    $site->external_ref = $ref;
+                }
+                $site->save();
+
+                $summary[$existed ? 'updated' : 'created']++;
+            }
+        });
+
+        return $summary;
+    }
+
+    /**
+     * A blank or out-of-range coordinate becomes null rather than an error - inventory
+     * exports routinely carry empty or 0,0 rows for sites nobody has surveyed yet, and one
+     * of those should not fail an import of thousands of good ones.
+     */
+    private function coord(mixed $value, float $limit): ?float
+    {
+        $raw = trim((string) $value);
+        if ($raw === '' || ! is_numeric($raw)) {
+            return null;
+        }
+
+        $num = (float) $raw;
+
+        return abs($num) <= $limit ? $num : null;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $str = trim((string) $value);
+
+        return $str === '' ? null : $str;
+    }
+}

--- a/app/Console/Commands/SitesImportCommand.php
+++ b/app/Console/Commands/SitesImportCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Sites\AssignDevicesToSites;
+use App\Actions\Sites\ImportSiteLinks;
+use App\Actions\Sites\ImportSites;
+use Illuminate\Console\Command;
+
+/**
+ * Load sites from a CSV and (optionally) place devices at them in one shot - the shell entry
+ * point ops use to sync an inventory. Safe to re-run: sites upsert on external_ref and the
+ * device passes never touch a manual placement.
+ */
+class SitesImportCommand extends Command
+{
+    protected $signature = 'mymate:sites:import
+        {file : CSV of sites (columns: name[,external_ref,kind,latitude,longitude,address,note])}
+        {--map= : also assign devices from a mgmt_ip,external_ref CSV (authoritative)}
+        {--links= : also import site-to-site backhauls from a site_a_ref,site_b_ref[,media_type] CSV}
+        {--nearest : also snap unassigned devices with their own coordinates to the closest site}
+        {--radius=0.5 : nearest-site snap radius in kilometres}';
+
+    protected $description = 'Import sites from CSV, and optionally assign devices + import backhauls.';
+
+    public function handle(ImportSites $importSites, AssignDevicesToSites $assign, ImportSiteLinks $importLinks): int
+    {
+        $file = (string) $this->argument('file');
+        if (! is_file($file)) {
+            $this->error("File not found: {$file}");
+
+            return self::FAILURE;
+        }
+
+        $this->info("Importing sites from {$file} ...");
+        $sites = $importSites($file);
+        $this->line(sprintf('  sites: %d created, %d updated, %d skipped',
+            $sites['created'], $sites['updated'], $sites['skipped']));
+
+        if (($map = $this->option('map')) !== null) {
+            if (! is_file((string) $map)) {
+                $this->error("Mapping file not found: {$map}");
+
+                return self::FAILURE;
+            }
+            $this->info("Assigning devices from mapping {$map} ...");
+            $m = $assign->fromMapping((string) $map);
+            $this->line(sprintf('  mapping: %d assigned, %d ip-unmatched, %d unknown-site, %d manual-kept',
+                $m['assigned'], $m['unmatched_ip'], $m['unknown_site'], $m['skipped_manual']));
+        }
+
+        if (($links = $this->option('links')) !== null) {
+            if (! is_file((string) $links)) {
+                $this->error("Links file not found: {$links}");
+
+                return self::FAILURE;
+            }
+            $this->info("Importing site backhauls from {$links} ...");
+            $l = $importLinks((string) $links);
+            $this->line(sprintf('  backhauls: %d created, %d updated, %d skipped',
+                $l['created'], $l['updated'], $l['skipped']));
+        }
+
+        if ($this->option('nearest')) {
+            $radius = max(0.0, (float) $this->option('radius'));
+            $this->info("Snapping unassigned devices to nearest site (<= {$radius} km) ...");
+            $n = $assign->byNearest($radius);
+            $this->line(sprintf('  nearest: %d assigned, %d too-far, %d considered',
+                $n['assigned'], $n['too_far'], $n['considered']));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Enums/SiteKind.php
+++ b/app/Enums/SiteKind.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * What kind of physical location a site is, for filtering and map styling. Purely a label -
+ * nothing in the engine behaves differently per kind. Stored as a plain string (enum cast on
+ * the model), so an unrecognised value from an import degrades to Other rather than failing.
+ */
+enum SiteKind: string
+{
+    case Tower = 'tower';       // wireless tower / mast / rooftop
+    case Cabinet = 'cabinet';   // fiber cabinet, OLT, splitter enclosure
+    case Pop = 'pop';           // point of presence, exchange, data centre
+    case Other = 'other';
+
+    public static function parse(?string $value): self
+    {
+        return self::tryFrom(mb_strtolower(trim((string) $value))) ?? self::Other;
+    }
+}

--- a/app/Http/Controllers/Api/DeviceController.php
+++ b/app/Http/Controllers/Api/DeviceController.php
@@ -25,9 +25,12 @@ class DeviceController extends Controller
 {
     public function index(): AnonymousResourceCollection
     {
-        $devices = Device::with('parent')->orderBy('name')->get();
-        // Resolve effective geo coordinates (own, else inherited from the uplink parent) in-memory
-        // for the whole set, so the geo map can place CPE that have no coordinates of their own.
+        // `site` is eager-loaded so DeviceGeo can read site coordinates without an N+1
+        // across the whole fleet.
+        $devices = Device::with(['parent', 'site'])->orderBy('name')->get();
+        // Resolve effective geo coordinates (own, else the site's, else inherited from the uplink
+        // parent) in-memory for the whole set, so the geo map can place CPE that have no
+        // coordinates of their own.
         \App\Support\DeviceGeo::apply($devices);
 
         return DeviceResource::collection($devices);
@@ -42,12 +45,20 @@ class DeviceController extends Controller
 
     public function show(Device $device): DeviceResource
     {
-        return new DeviceResource($device->loadMissing('parent'));
+        $device->loadMissing('parent', 'site');
+        // Single-device responses can still resolve own-or-site coordinates; only uplink
+        // inheritance needs the full set and stays a list-endpoint concern.
+        \App\Support\DeviceGeo::apply([$device]);
+
+        return new DeviceResource($device);
     }
 
     public function update(UpdateDeviceRequest $request, Device $device, UpdateDevice $updateDevice): DeviceResource
     {
-        return new DeviceResource($updateDevice($device, $request->validated())->loadMissing('parent'));
+        $device = $updateDevice($device, $request->validated())->loadMissing('parent', 'site');
+        \App\Support\DeviceGeo::apply([$device]);
+
+        return new DeviceResource($device);
     }
 
     public function updatePosition(UpdateDevicePositionRequest $request, Device $device, UpdateDevicePosition $updatePosition): DeviceResource

--- a/app/Http/Controllers/Api/GeoController.php
+++ b/app/Http/Controllers/Api/GeoController.php
@@ -3,8 +3,12 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\Device;
+use App\Support\DeviceGeo;
+use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 
 /**
@@ -24,6 +28,75 @@ class GeoController extends Controller
             'attribution' => (string) config('mymate.map.tile_attribution', ''),
             'geocoder_enabled' => (string) config('mymate.map.geocoder_url', '') !== '',
         ]]);
+    }
+
+    /**
+     * Compact placed-device feed for the geo map. Just what the map draws - id, name, status,
+     * site, effective coordinates, and how long a down device has been down - so the map doesn't
+     * have to pull the full multi-megabyte device resource just to plot dots and colour sites.
+     *
+     * Coordinates come from DeviceGeo, the same resolver the device resource uses (own pin, else
+     * the site's, else the uplink chain) - the fleet is hydrated slim (the handful of columns
+     * below) so resolving in one place stays affordable at large fleet sizes. Every device is
+     * loaded so uplink inheritance can pass through unmonitored/unplaced parents, but only
+     * monitored, placed devices are emitted (a paused device isn't on the live map).
+     *
+     * `down_since` is the still-open outage's `started_at` (the precise "went down" moment; a
+     * device's `last_change` is overwritten on recovery too, so it can't answer this). Read as a
+     * scalar subquery rather than a join: a device should only ever have one open outage, but a
+     * racing poller could briefly leave two, and a join would then emit the device twice and
+     * double-count it in the site's device/down tallies. MIN() also picks the earliest start,
+     * which is the honest answer for how long the thing has actually been dark.
+     */
+    public function devices(): JsonResponse
+    {
+        $devices = Device::query()
+            ->selectRaw('id, name, status, monitored, site_id, parent_device_id, latitude, longitude,
+                (SELECT MIN(o.started_at) FROM outages o
+                    WHERE o.device_id = devices.id AND o.ended_at IS NULL) AS down_since')
+            ->with('site:id,name,latitude,longitude')
+            ->get();
+
+        DeviceGeo::apply($devices);
+
+        $rows = $devices
+            ->filter(fn (Device $d) => $d->monitored && $d->geo_latitude !== null)
+            ->values()
+            ->map(fn (Device $d) => [
+                'id' => $d->id,
+                'name' => $d->name,
+                'status' => $d->status->value,
+                'site_id' => $d->site_id,
+                'lat' => $d->geo_latitude,
+                'lng' => $d->geo_longitude,
+                'down_since' => $d->down_since !== null
+                    ? Carbon::parse($d->down_since)->toIso8601String()
+                    : null,
+            ]);
+
+        return response()->json(['data' => $rows]);
+    }
+
+    /**
+     * Site-to-site backhaul links as coordinate pairs, for the geo map. Both ends resolved to
+     * their site's coordinates in SQL; only links whose sites are both placed are returned.
+     */
+    public function backhauls(): JsonResponse
+    {
+        $rows = DB::table('site_links as l')
+            ->join('sites as a', 'a.id', '=', 'l.site_a_id')
+            ->join('sites as b', 'b.id', '=', 'l.site_b_id')
+            ->whereNotNull('a.latitude')->whereNotNull('b.latitude')
+            ->selectRaw('l.id, l.media_type, a.longitude AS a_lng, a.latitude AS a_lat, b.longitude AS b_lng, b.latitude AS b_lat')
+            ->get()
+            ->map(fn ($r) => [
+                'id' => (int) $r->id,
+                'media_type' => $r->media_type,
+                'a' => [(float) $r->a_lng, (float) $r->a_lat],
+                'b' => [(float) $r->b_lng, (float) $r->b_lat],
+            ]);
+
+        return response()->json(['data' => $rows]);
     }
 
     /** Geocode an address to coordinates via the configured provider (proxied + best-effort). */

--- a/app/Http/Controllers/Api/SiteController.php
+++ b/app/Http/Controllers/Api/SiteController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Site\StoreSiteRequest;
+use App\Http\Requests\Site\UpdateSiteRequest;
+use App\Http\Resources\SiteResource;
+use App\Models\Site;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+
+/**
+ * Sites: the physical locations gear lives at. Read is open to any operator; writes are
+ * gated to admins by the global RestrictWritesToAdmins middleware.
+ *
+ * The index carries a device count and a down-count per site so the geo map can size and
+ * colour a whole tower from one payload, without pulling every device down with it.
+ */
+class SiteController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $sites = Site::query()
+            ->withCount('devices')
+            ->withCount(['devices as devices_down_count' => fn ($q) => $q->where('status', 'down')])
+            ->orderBy('name')
+            ->get();
+
+        return SiteResource::collection($sites);
+    }
+
+    public function store(StoreSiteRequest $request): SiteResource
+    {
+        $site = Site::create($request->validated());
+
+        return (new SiteResource($site))->additional(['created' => true]);
+    }
+
+    public function show(Site $site): SiteResource
+    {
+        return new SiteResource($site->loadCount('devices'));
+    }
+
+    public function update(UpdateSiteRequest $request, Site $site): SiteResource
+    {
+        $site->update($request->validated());
+
+        return new SiteResource($site->loadCount('devices'));
+    }
+
+    /**
+     * Deleting a site nulls its devices' site_id (FK nullOnDelete) rather than removing them -
+     * losing a tower record must never take the gear monitoring with it.
+     */
+    public function destroy(Site $site): Response
+    {
+        $site->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Device/UpdateDeviceRequest.php
+++ b/app/Http/Requests/Device/UpdateDeviceRequest.php
@@ -32,6 +32,9 @@ class UpdateDeviceRequest extends FormRequest
             // Geographic position (geo overlay). Both or neither; setting them marks the source manual.
             'latitude' => ['sometimes', 'nullable', 'numeric', 'between:-90,90', 'required_with:longitude'],
             'longitude' => ['sometimes', 'nullable', 'numeric', 'between:-180,180', 'required_with:latitude'],
+            // Site assignment through the editor. Setting it marks the source manual so a
+            // re-import or nearest-site pass never moves it (see UpdateDevice).
+            'site_id' => ['sometimes', 'nullable', 'integer', 'exists:sites,id'],
             'device_type' => ['sometimes', Rule::enum(DeviceType::class)],
             // Icon override: a named glyph key + a hex colour (both nullable = auto).
             'icon' => ['sometimes', 'nullable', 'string', 'max:40'],

--- a/app/Http/Requests/Site/StoreSiteRequest.php
+++ b/app/Http/Requests/Site/StoreSiteRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Site;
+
+use App\Enums\SiteKind;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreSiteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null; // authenticated operators only (writes gated to admins by middleware)
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'kind' => ['sometimes', Rule::enum(SiteKind::class)],
+            // Both or neither - a half-set coordinate can't be placed on the map.
+            'latitude' => ['nullable', 'numeric', 'between:-90,90', 'required_with:longitude'],
+            'longitude' => ['nullable', 'numeric', 'between:-180,180', 'required_with:latitude'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'external_ref' => ['nullable', 'string', 'max:255', Rule::unique('sites', 'external_ref')],
+            'note' => ['nullable', 'string', 'max:5000'],
+        ];
+    }
+}

--- a/app/Http/Requests/Site/UpdateSiteRequest.php
+++ b/app/Http/Requests/Site/UpdateSiteRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Site;
+
+use App\Enums\SiteKind;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateSiteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'kind' => ['sometimes', Rule::enum(SiteKind::class)],
+            'latitude' => ['sometimes', 'nullable', 'numeric', 'between:-90,90', 'required_with:longitude'],
+            'longitude' => ['sometimes', 'nullable', 'numeric', 'between:-180,180', 'required_with:latitude'],
+            'address' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'external_ref' => [
+                'sometimes', 'nullable', 'string', 'max:255',
+                Rule::unique('sites', 'external_ref')->ignore($this->route('site')?->id),
+            ],
+            'note' => ['sometimes', 'nullable', 'string', 'max:5000'],
+        ];
+    }
+}

--- a/app/Http/Resources/DeviceResource.php
+++ b/app/Http/Resources/DeviceResource.php
@@ -22,9 +22,15 @@ class DeviceResource extends JsonResource
             'latitude' => $this->latitude,
             'longitude' => $this->longitude,
             'geo_source' => $this->geo_source,
-            // Effective coordinates for the geo map (GitHub #21): own coords, else inherited from
-            // the uplink parent. Populated by DeviceGeo::apply on the list; single-device responses
-            // fall back to the device's own coords.
+            // Site placement: a site carries coordinates once and every device at it inherits
+            // them at read time, so assigning a site places a whole tower's worth of gear
+            // without copying coordinates onto each row.
+            'site_id' => $this->site_id,
+            'site_name' => $this->whenLoaded('site', fn () => $this->site?->name),
+            'site_source' => $this->site_source,
+            // Effective coordinates for the geo map (GitHub #21): own coords, else the site's,
+            // else inherited from the uplink parent. Populated by DeviceGeo::apply; responses
+            // that skip it fall back to the device's own coords.
             'geo_latitude' => $this->geo_latitude ?? $this->latitude,
             'geo_longitude' => $this->geo_longitude ?? $this->longitude,
             'geo_inherited' => (bool) ($this->geo_inherited ?? false),

--- a/app/Http/Resources/SiteResource.php
+++ b/app/Http/Resources/SiteResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SiteResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'kind' => $this->kind->value,
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+            'address' => $this->address,
+            'external_ref' => $this->external_ref,
+            'note' => $this->note,
+            // Present only when the caller asked for counts (the index does) - the map uses it
+            // to size a site marker, and the list to show how much gear is at each location.
+            'device_count' => $this->whenCounted('devices'),
+            // Rolled up from the devices at this site, so the map can colour a whole tower red
+            // without shipping every device down with it.
+            'devices_down' => $this->when(isset($this->devices_down_count), fn () => (int) $this->devices_down_count),
+        ];
+    }
+}

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -33,6 +33,7 @@ class Device extends Model
     protected $fillable = [
         'name', 'mgmt_ip', 'poll_method', 'credential_id', 'ssh_credential_id', 'routeros_credential_id', 'agent_id',
         'status', 'monitored', 'last_change', 'fail_streak', 'map_x', 'map_y', 'latitude', 'longitude', 'geo_source',
+        'site_id', 'site_source',
         'device_type', 'icon', 'icon_color', 'parent_device_id', 'vendor', 'model', 'serial', 'cpu', 'ram_bytes', 'arch', 'uptime_seconds', 'uptime_at',
         'os_version', 'latest_version', 'upgrade_status', 'upgrade_message', 'upgrade_at',
         'discovery_error', 'discovered_at',
@@ -109,6 +110,20 @@ class Device extends Model
     public function agent(): BelongsTo
     {
         return $this->belongsTo(Agent::class);
+    }
+
+    /**
+     * The physical location this device sits at, or null when it isn't assigned to one.
+     *
+     * The site's coordinates reach the geo map through DeviceGeo::resolve at read time rather
+     * than being copied into the device columns on assignment. Writing the site's coordinates
+     * onto every device would make a site that moves (a corrected survey, a rebuild) leave
+     * thousands of devices behind at the old position, and would make "has this device been
+     * placed itself?" unanswerable.
+     */
+    public function site(): BelongsTo
+    {
+        return $this->belongsTo(Site::class);
     }
 
     /** The upstream device this one depends on (drives the hierarchy + inspector). */

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\SiteKind;
+use Database\Factories\SiteFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * A physical location devices live at (see the create_sites_table migration for the why).
+ *
+ * A site holds coordinates once; the devices at it inherit them, so the geo map can place a
+ * whole tower's worth of gear without anyone dragging pins.
+ */
+class Site extends Model
+{
+    /** @use HasFactory<SiteFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'name', 'kind', 'latitude', 'longitude', 'address', 'external_ref', 'note',
+    ];
+
+    protected $casts = [
+        'kind' => SiteKind::class,
+        'latitude' => 'float',
+        'longitude' => 'float',
+    ];
+
+    protected $attributes = [
+        'kind' => 'other',
+    ];
+
+    /** @return HasMany<Device, $this> */
+    public function devices(): HasMany
+    {
+        return $this->hasMany(Device::class);
+    }
+
+    /** A site is only usable for placement once it has both coordinates. */
+    public function isPlaced(): bool
+    {
+        return $this->latitude !== null && $this->longitude !== null;
+    }
+
+    /**
+     * Great-circle distance to a point, in kilometres (haversine).
+     *
+     * Good enough for "which tower is this device at" - the error against a proper geodesic
+     * is metres over the tens-of-kilometres ranges that matter here, and it needs no
+     * PostGIS/spatial extension, which keeps a stock Postgres install working.
+     */
+    public function distanceKmTo(float $lat, float $lng): ?float
+    {
+        if (! $this->isPlaced()) {
+            return null;
+        }
+
+        $earthRadiusKm = 6371.0088;
+        $dLat = deg2rad($lat - $this->latitude);
+        $dLng = deg2rad($lng - $this->longitude);
+
+        $a = sin($dLat / 2) ** 2
+            + cos(deg2rad($this->latitude)) * cos(deg2rad($lat)) * sin($dLng / 2) ** 2;
+
+        return $earthRadiusKm * 2 * asin(min(1.0, sqrt($a)));
+    }
+}

--- a/app/Models/SiteLink.php
+++ b/app/Models/SiteLink.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A backhaul link between two sites (see the create_site_links_table migration). Imported from
+ * the OSS that owns the backbone topology so the geo map draws real tower-to-tower links.
+ */
+class SiteLink extends Model
+{
+    protected $fillable = ['site_a_id', 'site_b_id', 'media_type', 'external_ref'];
+
+    public function siteA(): BelongsTo
+    {
+        return $this->belongsTo(Site::class, 'site_a_id');
+    }
+
+    public function siteB(): BelongsTo
+    {
+        return $this->belongsTo(Site::class, 'site_b_id');
+    }
+}

--- a/app/Support/DeviceGeo.php
+++ b/app/Support/DeviceGeo.php
@@ -3,16 +3,18 @@
 namespace App\Support;
 
 use App\Models\Device;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 /**
- * Effective geo coordinates for devices (GitHub #21). A device with its own lat/lng keeps it; one
- * without inherits the nearest ancestor's up the `parent_device_id` (uplink) chain - so a CPE
- * behind a tower AP shows at the tower without geocoding thousands of endpoints. Resolved in-memory
+ * Effective geo coordinates for devices (GitHub #21). Precedence: a device with its own lat/lng
+ * keeps it; one without takes its site's coordinates; one with neither inherits from the nearest
+ * ancestor up the `parent_device_id` (uplink) chain, where each ancestor is itself read as
+ * own-pin-else-site - so a CPE behind a tower AP shows at the tower without geocoding thousands
+ * of endpoints, whether the tower was pinned by hand or placed via its site. Resolved in-memory
  * over the already-loaded device set (no per-device queries), so it holds up at large fleet sizes.
  *
  * Sets transient `geo_latitude` / `geo_longitude` / `geo_inherited` attributes that DeviceResource
- * reads. This is the lightweight inheritance path; an explicit Site/location model could later be
- * another source in the same resolution without changing callers.
+ * reads; `geo_inherited` is false only when the device's own pin was used.
  */
 class DeviceGeo
 {
@@ -23,6 +25,9 @@ class DeviceGeo
         foreach ($devices as $device) {
             $byId[$device->id] = $device;
         }
+
+        // One query for every site the set references, so resolve() never lazy-loads per device.
+        (new EloquentCollection(array_values($byId)))->loadMissing('site');
 
         foreach ($byId as $device) {
             [$lat, $lng, $inherited] = self::resolve($device, $byId);
@@ -42,8 +47,13 @@ class DeviceGeo
             return [(float) $device->latitude, (float) $device->longitude, false];
         }
 
-        // Walk the uplink chain to the first ancestor that has coordinates. Cycle-guarded, and
-        // bounded to ancestors present in the set (a parent off this page just ends the walk).
+        if (($own = self::siteCoordinates($device)) !== null) {
+            return [$own[0], $own[1], true];
+        }
+
+        // Walk the uplink chain to the first ancestor that resolves (own pin or site).
+        // Cycle-guarded, and bounded to ancestors present in the set (a parent off this
+        // page just ends the walk).
         $seen = [];
         $cursor = $device->parent_device_id;
         while ($cursor !== null && ! isset($seen[$cursor]) && isset($byId[$cursor])) {
@@ -52,9 +62,20 @@ class DeviceGeo
             if ($ancestor->latitude !== null && $ancestor->longitude !== null) {
                 return [(float) $ancestor->latitude, (float) $ancestor->longitude, true];
             }
+            if (($site = self::siteCoordinates($ancestor)) !== null) {
+                return [$site[0], $site[1], true];
+            }
             $cursor = $ancestor->parent_device_id;
         }
 
         return [null, null, false];
+    }
+
+    /** @return array{0: float, 1: float}|null The device's site's coordinates, when placed. */
+    private static function siteCoordinates(Device $device): ?array
+    {
+        $site = $device->relationLoaded('site') ? $device->site : null;
+
+        return $site?->isPlaced() ? [(float) $site->latitude, (float) $site->longitude] : null;
     }
 }

--- a/database/factories/SiteFactory.php
+++ b/database/factories/SiteFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SiteKind;
+use App\Models\Site;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<Site> */
+class SiteFactory extends Factory
+{
+    protected $model = Site::class;
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->streetName().' Tower',
+            'kind' => SiteKind::Tower,
+            'latitude' => fake()->latitude(),
+            'longitude' => fake()->longitude(),
+            'external_ref' => fake()->unique()->uuid(),
+        ];
+    }
+
+    /** A site with no coordinates yet (can't place devices). */
+    public function unplaced(): static
+    {
+        return $this->state(fn () => ['latitude' => null, 'longitude' => null]);
+    }
+
+    /** Pin the site at exact coordinates (nearest-site tests need known distances). */
+    public function at(float $lat, float $lng): static
+    {
+        return $this->state(fn () => ['latitude' => $lat, 'longitude' => $lng]);
+    }
+}

--- a/database/migrations/2026_07_23_000001_create_sites_table.php
+++ b/database/migrations/2026_07_23_000001_create_sites_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Sites: the physical locations gear lives at - a tower, a fiber cabinet, a POP, an exchange.
+ *
+ * Geo mode (GitHub #11) pins each device individually, which is fine for a handful of routers
+ * but does not survive a real access network: an operator with a few thousand devices spread
+ * over a few hundred towers does not want to drag a thousand pins, and the coordinates they
+ * already trust live in their OSS/inventory, not here. A site carries the coordinates once and
+ * every device at it inherits them, so placing a whole tower's worth of gear is one row.
+ *
+ * `external_ref` is the id this site has in whatever system owns the truth (an OSS/inventory, a
+ * spreadsheet). It's the idempotency key for re-imports - re-running an import updates in
+ * place instead of duplicating, so the source of truth can be re-synced on a schedule.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sites', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            // tower | cabinet | pop | other - a label for filtering and map styling, not a
+            // constraint. Kept as a string (not an enum column) so adding a kind is a code
+            // change, never a migration on a live table.
+            $table->string('kind', 16)->default('other');
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
+            $table->string('address')->nullable();
+            $table->string('external_ref')->nullable();
+            $table->text('note')->nullable();
+            $table->timestamps();
+
+            // Import upserts on this, and it's the natural lookup for a re-sync.
+            $table->unique('external_ref');
+            $table->index('kind');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sites');
+    }
+};

--- a/database/migrations/2026_07_23_000002_add_site_id_to_devices.php
+++ b/database/migrations/2026_07_23_000002_add_site_id_to_devices.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Which site a device sits at, and how that was decided.
+ *
+ * `site_source` mirrors the existing `geo_source` idea: an automatic pass (nearest-site, or an
+ * import keyed on an external system) must never overwrite a placement an operator made by
+ * hand, so anything set to `manual` is skipped by the assign action.
+ *
+ * Deleting a site nulls the link rather than deleting devices - losing a tower record should
+ * never take the gear monitoring with it.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->foreignId('site_id')->nullable()->after('geo_source')
+                ->constrained('sites')->nullOnDelete();
+            $table->string('site_source', 12)->nullable()->after('site_id'); // manual | import | nearest
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('site_id');
+            $table->dropColumn('site_source');
+        });
+    }
+};

--- a/database/migrations/2026_07_24_000002_create_site_links_table.php
+++ b/database/migrations/2026_07_24_000002_create_site_links_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Backhaul links between two sites - the physical topology of what connects to what.
+ *
+ * Unlike the interface-level device links (which need both ends polled), these are site-to-site
+ * and imported from the OSS that actually knows the backbone, so the geo map can draw the real
+ * tower-to-tower backhauls instead of inferring them from device links between possibly-misplaced
+ * devices. `external_ref` makes an import idempotent.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('site_links', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('site_a_id')->constrained('sites')->cascadeOnDelete();
+            $table->foreignId('site_b_id')->constrained('sites')->cascadeOnDelete();
+            $table->string('media_type', 16)->nullable(); // fiber | wireless | other
+            $table->string('external_ref')->nullable();
+            $table->timestamps();
+
+            $table->unique('external_ref');
+            $table->index(['site_a_id', 'site_b_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('site_links');
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "mymate",
+    "name": "mymate-rework",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -11,11 +11,13 @@
                 "@tanstack/react-query": "^5.101.1",
                 "@types/d3-force": "^3.0.10",
                 "@types/leaflet": "^1.9.21",
+                "@types/leaflet.markercluster": "^1.5.6",
                 "@xyflow/react": "^12.11.1",
                 "axios": "^1.18.1",
                 "d3-force": "^3.0.0",
                 "laravel-echo": "^2.3.7",
                 "leaflet": "^1.9.4",
+                "leaflet.markercluster": "^1.5.3",
                 "pusher-js": "^8.5.0",
                 "react": "^19.2.7",
                 "react-dom": "^19.2.7"
@@ -828,6 +830,15 @@
                 "@types/geojson": "*"
             }
         },
+        "node_modules/@types/leaflet.markercluster": {
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/@types/leaflet.markercluster/-/leaflet.markercluster-1.5.6.tgz",
+            "integrity": "sha512-I7hZjO2+isVXGYWzKxBp8PsCzAYCJBc29qBdFpquOCkS7zFDqUsUvkEOyQHedsk/Cy5tocQzf+Ndorm5W9YKTQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/leaflet": "^1.9"
+            }
+        },
         "node_modules/@types/react": {
             "version": "19.2.17",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -1633,6 +1644,15 @@
             "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
             "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
             "license": "BSD-2-Clause"
+        },
+        "node_modules/leaflet.markercluster": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+            "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "leaflet": "^1.3.1"
+            }
         },
         "node_modules/lightningcss": {
             "version": "1.32.0",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
         "@tanstack/react-query": "^5.101.1",
         "@types/d3-force": "^3.0.10",
         "@types/leaflet": "^1.9.21",
+        "@types/leaflet.markercluster": "^1.5.6",
         "@xyflow/react": "^12.11.1",
         "axios": "^1.18.1",
         "d3-force": "^3.0.0",
         "laravel-echo": "^2.3.7",
         "leaflet": "^1.9.4",
+        "leaflet.markercluster": "^1.5.3",
         "pusher-js": "^8.5.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/resources/js/features/geo/api/sites.ts
+++ b/resources/js/features/geo/api/sites.ts
@@ -1,0 +1,78 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../../../lib/apiClient';
+
+export interface Site {
+    id: number;
+    name: string;
+    kind: string;
+    latitude: number | null;
+    longitude: number | null;
+    address: string | null;
+    external_ref: string | null;
+    note: string | null;
+    device_count?: number;
+    devices_down?: number;
+}
+
+export const siteKeys = {
+    all: ['sites'] as const,
+    list: () => [...siteKeys.all, 'list'] as const,
+};
+
+/** A device as the geo map needs it - compact, so the map doesn't pull the full device list. */
+export interface GeoDevice {
+    id: number;
+    name: string;
+    status: 'up' | 'down' | 'unknown';
+    site_id: number | null;
+    lat: number;
+    lng: number;
+    /** Start of the still-open outage (ISO) - null when the device isn't currently down. */
+    down_since: string | null;
+}
+
+/**
+ * Compact placed-device feed for the geo map (id/name/status/site/coords only) - a fraction of
+ * the full /devices payload. Refetched periodically so site health + device dots stay current.
+ */
+export function useGeoDevices() {
+    return useQuery({
+        queryKey: ['geo', 'devices'],
+        queryFn: async (): Promise<GeoDevice[]> => {
+            const { data } = await apiClient.get<{ data: GeoDevice[] }>('/geo/devices');
+            return data.data;
+        },
+        refetchInterval: 15000,
+    });
+}
+
+/** A site-to-site backhaul link as coordinate pairs (from the OSS backbone topology). */
+export interface Backhaul {
+    id: number;
+    media_type: string | null;
+    a: [number, number]; // [lng, lat]
+    b: [number, number];
+}
+
+/** Site-to-site backhaul links for the geo map (real topology, imported from the OSS). */
+export function useBackhauls() {
+    return useQuery({
+        queryKey: ['geo', 'backhauls'],
+        queryFn: async (): Promise<Backhaul[]> => {
+            const { data } = await apiClient.get<{ data: Backhaul[] }>('/geo/backhauls');
+            return data.data;
+        },
+        staleTime: 5 * 60 * 1000, // topology changes rarely
+    });
+}
+
+/** All sites with their device + down counts (the geo map's primary markers). */
+export function useSites() {
+    return useQuery({
+        queryKey: siteKeys.list(),
+        queryFn: async (): Promise<Site[]> => {
+            const { data } = await apiClient.get<{ data: Site[] }>('/sites');
+            return data.data;
+        },
+    });
+}

--- a/resources/js/features/geo/components/GeoView.tsx
+++ b/resources/js/features/geo/components/GeoView.tsx
@@ -1,15 +1,32 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+// Marker clustering: an access network puts thousands of devices on a few thousand sites, all
+// stacked on the same points. Drawing every marker at once locks the browser; the cluster group
+// collapses them into count-bubbles that split apart as you zoom, so the whole fleet renders
+// smoothly. The default cluster icons are CSS-drawn divs (no image requests), so it stays
+// CSP-clean like the rest of the map.
+import 'leaflet.markercluster';
+import 'leaflet.markercluster/dist/MarkerCluster.css';
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 import { MagnifyingGlass, MapPin, X } from '@phosphor-icons/react';
 import { useDevices } from '../../devices/api/getDevices';
 import { useUpdateDevice } from '../../devices/api/updateDevice';
 import { useIsAdmin } from '../../auth/api/auth';
 import { useMapConfig, useGeocode } from '../api/geo';
+import { useBackhauls } from '../api/sites';
+import { LayerToggle, loadLayerPrefs, persistLayerPrefs, type LayerPrefs } from './geoLayers';
 import { pushToast } from '../../../lib/toast';
 import type { Device, DeviceStatus } from '../../../types';
 
 const STATUS_COLOR: Record<DeviceStatus, string> = { up: '#34d399', down: '#f43f5e', unknown: '#52525b' };
+
+// What a device draws at: its own pin when it has one, otherwise its site's coordinates (the
+// backend resolves this into geo_latitude/geo_longitude). A device sitting at a placed site is
+// therefore "placed" here without an own pin, so it shows on the map and drops out of the
+// unplaced list. Dragging it still writes its own latitude/longitude (an explicit override).
+const geoLat = (d: Device): number | null => d.geo_latitude;
+const geoLng = (d: Device): number | null => d.geo_longitude;
 
 /** A status-coloured pin as an HTML div icon (no external marker images -> CSP-clean). */
 function pinIcon(status: DeviceStatus): L.DivIcon {
@@ -31,8 +48,18 @@ export function GeoView() {
     const isAdmin = useIsAdmin();
     const { data: config } = useMapConfig();
     const { data: devices } = useDevices();
+    const { data: backhauls } = useBackhauls();
     const update = useUpdateDevice();
     const geocode = useGeocode();
+
+    // Which layers are on (persisted across reloads, shared with the other geo renderers).
+    const [layers, setLayers] = useState<LayerPrefs>(loadLayerPrefs);
+    const toggleLayer = (key: keyof LayerPrefs) =>
+        setLayers((prev) => {
+            const next = { ...prev, [key]: !prev[key] };
+            persistLayerPrefs(next);
+            return next;
+        });
 
     const mapRef = useRef<L.Map | null>(null);
     // Effects that draw on the map key off this, not mapRef: the map is created
@@ -43,11 +70,13 @@ export function GeoView() {
     const [mapReady, setMapReady] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
     const markersRef = useRef<Map<number, L.Marker>>(new Map());
+    const clusterRef = useRef<L.MarkerClusterGroup | null>(null);
+    const backhaulLayerRef = useRef<L.LayerGroup | null>(null);
     const [placingId, setPlacingId] = useState<number | null>(null); // device awaiting a click-to-place
     const [address, setAddress] = useState('');
 
-    const placed = useMemo(() => (devices ?? []).filter((d) => d.latitude != null && d.longitude != null), [devices]);
-    const unplaced = useMemo(() => (devices ?? []).filter((d) => d.latitude == null || d.longitude == null), [devices]);
+    const placed = useMemo(() => (devices ?? []).filter((d) => geoLat(d) != null && geoLng(d) != null), [devices]);
+    const unplaced = useMemo(() => (devices ?? []).filter((d) => geoLat(d) == null || geoLng(d) == null), [devices]);
     const placingRef = useRef<number | null>(null);
     placingRef.current = placingId;
 
@@ -60,6 +89,17 @@ export function GeoView() {
         const map = L.map(containerRef.current, { center: [20, 0], zoom: 2, worldCopyJump: true });
         L.tileLayer(config.tile_url, { attribution: config.attribution, maxZoom: 19 }).addTo(map);
         mapRef.current = map;
+
+        // One cluster group holds every device marker. chunkedLoading keeps the main thread
+        // free while thousands are added; spiderfy fans out the co-located devices at a site
+        // when you click its cluster at max zoom.
+        const cluster = L.markerClusterGroup({ chunkedLoading: true, maxClusterRadius: 48, spiderfyOnMaxZoom: true });
+        cluster.addTo(map);
+        clusterRef.current = cluster;
+
+        // Backhaul lines live in their own group, under the markers, so the toggle can add and
+        // remove them without touching the cluster.
+        backhaulLayerRef.current = L.layerGroup();
         setMapReady(true);
 
         // Click the map to drop the device currently being placed.
@@ -71,37 +111,84 @@ export function GeoView() {
             }
         });
 
-        return () => { map.remove(); mapRef.current = null; markersRef.current.clear(); setMapReady(false); };
+        return () => {
+            map.remove();
+            mapRef.current = null;
+            clusterRef.current = null;
+            backhaulLayerRef.current = null;
+            markersRef.current.clear();
+            setMapReady(false);
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [config?.enabled]);
 
-    // Sync markers to the placed devices.
+    // Sync markers (inside the cluster group) to the placed devices. Add/remove go through the
+    // cluster group so it re-clusters incrementally rather than redrawing the whole fleet.
     useEffect(() => {
-        const map = mapRef.current;
-        if (!map) return;
+        const cluster = clusterRef.current;
+        if (!cluster) return;
         const seen = new Set<number>();
+        const toAdd: L.Marker[] = [];
 
         for (const d of placed) {
             seen.add(d.id);
-            const pos: L.LatLngExpression = [d.latitude as number, d.longitude as number];
+            const pos: L.LatLngExpression = [geoLat(d) as number, geoLng(d) as number];
             let marker = markersRef.current.get(d.id);
             if (!marker) {
                 marker = L.marker(pos, { icon: pinIcon(d.status), draggable: isAdmin, title: d.name });
                 marker.bindTooltip(d.name, { direction: 'top', offset: [0, -8] });
                 marker.on('dragend', () => { const p = marker!.getLatLng(); save(d.id, p.lat, p.lng); });
-                marker.addTo(map);
                 markersRef.current.set(d.id, marker);
+                toAdd.push(marker);
             } else {
                 marker.setLatLng(pos);
                 marker.setIcon(pinIcon(d.status));
             }
         }
+        if (toAdd.length) cluster.addLayers(toAdd);
+
         // Drop markers for devices no longer placed.
+        const toRemove: L.Marker[] = [];
         for (const [id, marker] of markersRef.current) {
-            if (!seen.has(id)) { marker.remove(); markersRef.current.delete(id); }
+            if (!seen.has(id)) { toRemove.push(marker); markersRef.current.delete(id); }
         }
+        if (toRemove.length) cluster.removeLayers(toRemove);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [placed, isAdmin, mapReady]);
+
+    // Device-layer toggle: the cluster group leaves/joins the map whole. The markers inside it
+    // stay synced by the effect above either way, so re-enabling is instant.
+    useEffect(() => {
+        const map = mapRef.current;
+        const cluster = clusterRef.current;
+        if (!map || !cluster) return;
+        if (layers.sites && !map.hasLayer(cluster)) cluster.addTo(map);
+        if (!layers.sites && map.hasLayer(cluster)) map.removeLayer(cluster);
+    }, [layers.sites, mapReady]);
+
+    // Backhaul lines: site-to-site links from the OSS backbone topology, drawn under the
+    // markers - solid for fiber, dashed for wireless (matching the vector renderer). Rebuilt
+    // whole on data change; the topology is a few hundred lines at most, so that's cheap.
+    useEffect(() => {
+        const map = mapRef.current;
+        const group = backhaulLayerRef.current;
+        if (!map || !group) return;
+        group.clearLayers();
+        if (layers.backhauls) {
+            for (const l of backhauls ?? []) {
+                const wireless = l.media_type === 'wireless';
+                group.addLayer(L.polyline(
+                    [[l.a[1], l.a[0]], [l.b[1], l.b[0]]], // feed is [lng, lat]
+                    wireless
+                        ? { color: '#8b9cb3', weight: 1.5, opacity: 0.55, dashArray: '4 3', interactive: false }
+                        : { color: '#5b8def', weight: 1.5, opacity: 0.6, interactive: false },
+                ));
+            }
+            if (!map.hasLayer(group)) group.addTo(map);
+        } else if (map.hasLayer(group)) {
+            map.removeLayer(group);
+        }
+    }, [backhauls, layers.backhauls, mapReady]);
 
     // Fit to the placed devices the first time there are any.
     const fittedRef = useRef(false);
@@ -109,7 +196,7 @@ export function GeoView() {
         const map = mapRef.current;
         if (!map || fittedRef.current || placed.length === 0) return;
         fittedRef.current = true;
-        const bounds = L.latLngBounds(placed.map((d) => [d.latitude as number, d.longitude as number] as L.LatLngExpression));
+        const bounds = L.latLngBounds(placed.map((d) => [geoLat(d) as number, geoLng(d) as number] as L.LatLngExpression));
         map.fitBounds(bounds, { padding: [60, 60], maxZoom: 14 });
     }, [placed, mapReady]);
 
@@ -138,6 +225,12 @@ export function GeoView() {
     return (
         <div className="relative flex h-full">
             <div ref={containerRef} className="h-full flex-1 bg-[#0d0d11]" style={{ zIndex: 0 }} />
+
+            {/* Layer toggles - what's on the map is a matter of what the operator is doing. */}
+            <div className="absolute bottom-4 left-3 z-[500] flex gap-1.5">
+                <LayerToggle label="Devices" on={layers.sites} onClick={() => toggleLayer('sites')} title="Show device markers" />
+                <LayerToggle label="Backhauls" on={layers.backhauls} onClick={() => toggleLayer('backhauls')} title="Show site-to-site backhaul lines" />
+            </div>
 
             {/* Placement panel (admin) - place devices that have no coordinates yet. */}
             {isAdmin && (

--- a/resources/js/features/geo/components/geoLayers.tsx
+++ b/resources/js/features/geo/components/geoLayers.tsx
@@ -1,0 +1,56 @@
+/**
+ * Which geo-map layers are on, remembered across reloads. Shared by every geo renderer so a
+ * preference set in one survives a config change to another: `sites` is the map's content
+ * markers (device pins in the Leaflet view; site markers in renderers whose unit is the site),
+ * `backhauls` the site-to-site lines, `weather` an optional radar overlay a renderer may offer.
+ *
+ * Sites and backhauls are the map's actual content, so they start on; weather is context an
+ * operator asks for, and it costs a third-party fetch, so it starts off.
+ */
+export type LayerPrefs = { sites: boolean; backhauls: boolean; weather: boolean };
+
+const LAYER_PREFS_KEY = 'mymate.geo.layers';
+
+export const LAYER_DEFAULTS: LayerPrefs = { sites: true, backhauls: true, weather: false };
+
+export function loadLayerPrefs(): LayerPrefs {
+    if (typeof window === 'undefined') return LAYER_DEFAULTS;
+    try {
+        const raw = window.localStorage.getItem(LAYER_PREFS_KEY);
+        const saved = raw ? (JSON.parse(raw) as Partial<LayerPrefs>) : {};
+        return {
+            sites: typeof saved.sites === 'boolean' ? saved.sites : LAYER_DEFAULTS.sites,
+            backhauls: typeof saved.backhauls === 'boolean' ? saved.backhauls : LAYER_DEFAULTS.backhauls,
+            weather: typeof saved.weather === 'boolean' ? saved.weather : LAYER_DEFAULTS.weather,
+        };
+    } catch {
+        return LAYER_DEFAULTS; // storage disabled or corrupt - fall back, never blank the map
+    }
+}
+
+export function persistLayerPrefs(prefs: LayerPrefs): void {
+    try {
+        window.localStorage.setItem(LAYER_PREFS_KEY, JSON.stringify(prefs));
+    } catch {
+        /* storage disabled or over quota - the toggles still work for this session */
+    }
+}
+
+/** One layer pill. Emerald when the layer is on, glass when it's off. */
+export function LayerToggle({ label, on, onClick, title }: { label: string; on: boolean; onClick: () => void; title: string }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            title={title}
+            aria-pressed={on}
+            className={`rounded-lg px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] ring-1 backdrop-blur transition-colors ${
+                on
+                    ? 'bg-emerald-500/20 text-emerald-200 ring-emerald-400/40'
+                    : 'bg-black/50 text-white/55 ring-white/15 hover:bg-black/70 hover:text-white/80'
+            }`}
+        >
+            {label}
+        </button>
+    );
+}

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -40,7 +40,12 @@ export interface Device {
     latitude: number | null; // geo overlay position (the device's own coords)
     longitude: number | null;
     geo_source: 'manual' | 'address' | 'snmp' | null;
-    // Effective coords for the geo map (GitHub #21): own, else inherited from the uplink parent.
+    // Site placement: assigning a site places the device at it without copying coordinates.
+    site_id: number | null;
+    site_name: string | null;
+    site_source: 'manual' | 'import' | 'nearest' | null;
+    // Effective coords for the geo map (GitHub #21): own, else the site's, else inherited from
+    // the uplink parent.
     geo_latitude: number | null;
     geo_longitude: number | null;
     geo_inherited: boolean;

--- a/routes/api.php
+++ b/routes/api.php
@@ -60,6 +60,10 @@ Route::middleware(['auth:sanctum', RestrictWritesToAdmins::class, \App\Http\Midd
         ->middleware('throttle:20,1')->name('update-check');
     // Geo overlay: tile config + a server-side geocoder proxy (GitHub #11).
     Route::get('map-config', [\App\Http\Controllers\Api\GeoController::class, 'config'])->name('map.config');
+    // Compact placed-device feed for the geo map (id/name/status/site/coords only).
+    Route::get('geo/devices', [\App\Http\Controllers\Api\GeoController::class, 'devices'])->name('geo.devices');
+    // Site-to-site backhaul links (coordinate pairs) for the geo map.
+    Route::get('geo/backhauls', [\App\Http\Controllers\Api\GeoController::class, 'backhauls'])->name('geo.backhauls');
     Route::get('geocode', [\App\Http\Controllers\Api\GeoController::class, 'geocode'])
         ->middleware('throttle:30,1')->name('geocode');
     // System status board (db/redis/workers/polling/websockets/backups) for Settings.

--- a/routes/api.php
+++ b/routes/api.php
@@ -275,6 +275,11 @@ Route::middleware(['auth:sanctum', RestrictWritesToAdmins::class, \App\Http\Midd
     Route::get('alert-events', [AlertEventController::class, 'index'])->name('alert-events.index');
     Route::post('alert-events/{alertEvent}/ack', [AlertEventController::class, 'ack'])->name('alert-events.ack');
 
+    // Sites: physical locations (towers, fiber cabinets, POPs) devices sit at. Devices
+    // inherit their site's coordinates on the geo map, so a whole tower places at once.
+    Route::apiResource('sites', \App\Http\Controllers\Api\SiteController::class)
+        ->only(['index', 'show', 'store', 'update', 'destroy']);
+
     // Auto-discovery: authorized scan ranges + the candidate review queue.
     Route::apiResource('subnets', SubnetController::class)->only(['index', 'store', 'update', 'destroy']);
     Route::post('subnets/{subnet}/scan', [SubnetController::class, 'scan'])

--- a/tests/Feature/DeviceSiteGeoTest.php
+++ b/tests/Feature/DeviceSiteGeoTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Device;
+use App\Models\Site;
+use App\Support\DeviceGeo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Devices inherit their site's coordinates on the geo map, unless they carry their own pin.
+ * This is the whole point of sites - place a tower once, every device at it follows. The site
+ * slots into DeviceGeo's resolution between the device's own pin and the uplink-ancestor walk.
+ */
+class DeviceSiteGeoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actingAsUser();
+    }
+
+    public function test_a_device_inherits_its_sites_coordinates(): void
+    {
+        $site = Site::factory()->at(40.12345, -100.54321)->create();
+        Device::factory()->create(['site_id' => $site->id, 'latitude' => null, 'longitude' => null]);
+
+        $this->getJson('/api/devices')
+            ->assertOk()
+            ->assertJsonPath('data.0.geo_latitude', 40.12345)
+            ->assertJsonPath('data.0.geo_longitude', -100.54321)
+            ->assertJsonPath('data.0.geo_inherited', true)
+            ->assertJsonPath('data.0.site_name', $site->name);
+    }
+
+    public function test_a_devices_own_pin_wins_over_its_site(): void
+    {
+        $site = Site::factory()->at(40.12345, -100.54321)->create();
+        $device = Device::factory()->create(['site_id' => $site->id, 'latitude' => 10.0, 'longitude' => 20.0]);
+
+        DeviceGeo::apply([$device->load('site')]);
+
+        $this->assertSame(10.0, $device->geo_latitude);
+        $this->assertSame(20.0, $device->geo_longitude);
+        $this->assertFalse($device->geo_inherited);
+    }
+
+    public function test_a_devices_site_wins_over_its_uplink_ancestor(): void
+    {
+        $site = Site::factory()->at(40.0, -100.0)->create();
+        $tower = Device::factory()->create(['latitude' => -27.4, 'longitude' => 153.1]);
+        $cpe = Device::factory()->create([
+            'site_id' => $site->id, 'latitude' => null, 'longitude' => null, 'parent_device_id' => $tower->id,
+        ]);
+
+        DeviceGeo::apply([$tower, $cpe]);
+
+        $this->assertSame(40.0, $cpe->geo_latitude);
+        $this->assertSame(-100.0, $cpe->geo_longitude);
+        $this->assertTrue($cpe->geo_inherited);
+    }
+
+    public function test_an_ancestor_placed_only_by_its_site_still_anchors_its_children(): void
+    {
+        $site = Site::factory()->at(40.0, -100.0)->create();
+        $ap = Device::factory()->create(['site_id' => $site->id, 'latitude' => null, 'longitude' => null]);
+        $cpe = Device::factory()->create([
+            'latitude' => null, 'longitude' => null, 'parent_device_id' => $ap->id,
+        ]);
+
+        DeviceGeo::apply([$ap, $cpe]);
+
+        $this->assertSame(40.0, $cpe->geo_latitude);
+        $this->assertSame(-100.0, $cpe->geo_longitude);
+        $this->assertTrue($cpe->geo_inherited);
+    }
+
+    public function test_a_device_with_no_pin_and_an_unplaced_site_has_no_coordinates(): void
+    {
+        $site = Site::factory()->unplaced()->create();
+        Device::factory()->create(['site_id' => $site->id, 'latitude' => null, 'longitude' => null]);
+
+        $this->getJson('/api/devices')->assertJsonPath('data.0.geo_latitude', null);
+    }
+
+    public function test_the_single_device_endpoint_resolves_site_coordinates_too(): void
+    {
+        $site = Site::factory()->at(40.12345, -100.54321)->create();
+        $device = Device::factory()->create(['site_id' => $site->id, 'latitude' => null, 'longitude' => null]);
+
+        $this->getJson("/api/devices/{$device->id}")
+            ->assertOk()
+            ->assertJsonPath('data.geo_latitude', 40.12345)
+            ->assertJsonPath('data.geo_longitude', -100.54321);
+    }
+
+    public function test_assigning_a_site_through_the_editor_marks_it_manual(): void
+    {
+        $site = Site::factory()->at(40.5, -100.25)->create();
+        $device = Device::factory()->create(['latitude' => null, 'longitude' => null]);
+
+        $this->patchJson("/api/devices/{$device->id}", ['site_id' => $site->id])
+            ->assertOk()
+            ->assertJsonPath('data.site_id', $site->id)
+            ->assertJsonPath('data.site_source', 'manual')
+            ->assertJsonPath('data.geo_latitude', 40.5);
+    }
+}

--- a/tests/Feature/GeoFeedsTest.php
+++ b/tests/Feature/GeoFeedsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\DeviceStatus;
+use App\Models\Device;
+use App\Models\Outage;
+use App\Models\Site;
+use App\Models\SiteLink;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The compact geo feeds: /geo/devices (what the map draws, coordinates via DeviceGeo)
+ * and /geo/backhauls (site-to-site links as coordinate pairs).
+ */
+class GeoFeedsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actingAsUser();
+    }
+
+    public function test_devices_feed_resolves_site_coordinates_and_skips_the_unplaced(): void
+    {
+        $site = Site::factory()->at(40.1, -100.2)->create();
+        $atSite = Device::factory()->create(['site_id' => $site->id, 'latitude' => null, 'longitude' => null]);
+        Device::factory()->create(['name' => 'nowhere', 'latitude' => null, 'longitude' => null]);
+
+        $rows = $this->getJson('/api/geo/devices')->assertOk()->json('data');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame($atSite->id, $rows[0]['id']);
+        $this->assertSame(40.1, $rows[0]['lat']);
+        $this->assertSame(-100.2, $rows[0]['lng']);
+        $this->assertSame($site->id, $rows[0]['site_id']);
+    }
+
+    public function test_devices_feed_inherits_through_an_unmonitored_uplink_parent(): void
+    {
+        // The parent is off the map (unmonitored) but still anchors its child's position.
+        $parent = Device::factory()->create(['monitored' => false, 'latitude' => -27.4, 'longitude' => 153.1]);
+        $cpe = Device::factory()->create([
+            'latitude' => null, 'longitude' => null, 'parent_device_id' => $parent->id,
+        ]);
+
+        $rows = $this->getJson('/api/geo/devices')->assertOk()->json('data');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame($cpe->id, $rows[0]['id']);
+        $this->assertSame(-27.4, $rows[0]['lat']);
+    }
+
+    public function test_devices_feed_reports_down_since_from_the_open_outage_without_duplicating(): void
+    {
+        $device = Device::factory()->create(['status' => DeviceStatus::Down, 'latitude' => 1.0, 'longitude' => 2.0]);
+        // Two open outages (a racing poller's brief overlap) must not emit the device twice,
+        // and the earlier start is the honest "how long has this been dark".
+        $early = Outage::factory()->create(['device_id' => $device->id, 'started_at' => now()->subHours(5)]);
+        Outage::factory()->create(['device_id' => $device->id, 'started_at' => now()->subHours(2)]);
+
+        $rows = $this->getJson('/api/geo/devices')->assertOk()->json('data');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame($early->started_at->toIso8601String(), $rows[0]['down_since']);
+    }
+
+    public function test_backhauls_feed_returns_coordinate_pairs_and_skips_unplaced_ends(): void
+    {
+        $a = Site::factory()->at(40.5, -100.25)->create();
+        $b = Site::factory()->at(41.5, -101.75)->create();
+        $unplaced = Site::factory()->unplaced()->create();
+        $link = SiteLink::create(['site_a_id' => $a->id, 'site_b_id' => $b->id, 'media_type' => 'wireless']);
+        SiteLink::create(['site_a_id' => $a->id, 'site_b_id' => $unplaced->id, 'media_type' => 'fiber']);
+
+        $rows = $this->getJson('/api/geo/backhauls')->assertOk()->json('data');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame($link->id, $rows[0]['id']);
+        $this->assertSame('wireless', $rows[0]['media_type']);
+        $this->assertSame([-100.25, 40.5], $rows[0]['a']);
+        $this->assertSame([-101.75, 41.5], $rows[0]['b']);
+    }
+}

--- a/tests/Feature/SiteApiTest.php
+++ b/tests/Feature/SiteApiTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Device;
+use App\Models\Site;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SiteApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actingAsUser();
+    }
+
+    public function test_lists_sites_with_device_and_down_counts(): void
+    {
+        $site = Site::factory()->create();
+        Device::factory()->count(3)->create(['site_id' => $site->id]);
+        Device::factory()->create(['site_id' => $site->id, 'status' => 'down']);
+
+        $this->getJson('/api/sites')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.device_count', 4)
+            ->assertJsonPath('data.0.devices_down', 1);
+    }
+
+    public function test_creates_a_site(): void
+    {
+        $this->postJson('/api/sites', [
+            'name' => 'North Tower', 'kind' => 'tower', 'latitude' => 40.0, 'longitude' => -100.0,
+            'external_ref' => 'inv:abc-123',
+        ])
+            ->assertCreated()
+            ->assertJsonPath('data.name', 'North Tower')
+            ->assertJsonPath('data.kind', 'tower');
+
+        $this->assertDatabaseHas('sites', ['external_ref' => 'inv:abc-123', 'name' => 'North Tower']);
+    }
+
+    public function test_rejects_a_half_set_coordinate(): void
+    {
+        $this->postJson('/api/sites', ['name' => 'Half', 'latitude' => 40.0])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['longitude']);
+    }
+
+    public function test_rejects_a_duplicate_external_ref(): void
+    {
+        Site::factory()->create(['external_ref' => 'inv:dup']);
+
+        $this->postJson('/api/sites', ['name' => 'Other', 'external_ref' => 'inv:dup'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['external_ref']);
+    }
+
+    public function test_deleting_a_site_detaches_its_devices_rather_than_removing_them(): void
+    {
+        $site = Site::factory()->create();
+        $device = Device::factory()->create(['site_id' => $site->id, 'site_source' => 'import']);
+
+        $this->deleteJson("/api/sites/{$site->id}")->assertNoContent();
+
+        $this->assertDatabaseMissing('sites', ['id' => $site->id]);
+        $this->assertDatabaseHas('devices', ['id' => $device->id, 'site_id' => null]);
+    }
+
+    public function test_non_admin_cannot_create_a_site(): void
+    {
+        $this->actingAs(User::factory()->create()); // read-only tier
+
+        $this->postJson('/api/sites', ['name' => 'Nope'])->assertForbidden();
+    }
+}

--- a/tests/Feature/SiteImportAssignTest.php
+++ b/tests/Feature/SiteImportAssignTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\Sites\AssignDevicesToSites;
+use App\Actions\Sites\ImportSites;
+use App\Models\Device;
+use App\Models\Site;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SiteImportAssignTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function csv(string $body): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'mmcsv').'.csv';
+        file_put_contents($path, $body);
+
+        return $path;
+    }
+
+    public function test_import_upserts_sites_on_external_ref(): void
+    {
+        $import = app(ImportSites::class);
+
+        $first = $import($this->csv("name,external_ref,kind,latitude,longitude\nNorth Tower,inv:1,tower,40.00,-100.00\n"));
+        $this->assertSame(['created' => 1, 'updated' => 0, 'skipped' => 0], $first);
+
+        // Same external_ref, corrected coordinate -> update in place, not a duplicate.
+        $second = $import($this->csv("name,external_ref,kind,latitude,longitude\nNorth Tower West,inv:1,tower,40.01,-100.01\n"));
+        $this->assertSame(['created' => 0, 'updated' => 1, 'skipped' => 0], $second);
+
+        $this->assertDatabaseCount('sites', 1);
+        $this->assertDatabaseHas('sites', ['external_ref' => 'inv:1', 'name' => 'North Tower West', 'latitude' => 40.01]);
+    }
+
+    public function test_import_skips_rows_with_no_name_and_nulls_bad_coordinates(): void
+    {
+        $summary = app(ImportSites::class)($this->csv(
+            "name,external_ref,latitude,longitude\n,inv:x,1,2\nGood,inv:y,999,0\n"
+        ));
+
+        $this->assertSame(1, $summary['skipped']); // nameless row
+        $this->assertSame(1, $summary['created']);
+        $this->assertDatabaseHas('sites', ['external_ref' => 'inv:y', 'latitude' => null]); // 999 is out of range -> null
+    }
+
+    public function test_mapping_assignment_matches_device_ip_to_site_ref(): void
+    {
+        $site = Site::factory()->create(['external_ref' => 'inv:tower-9']);
+        $device = Device::factory()->create(['mgmt_ip' => '10.0.2.42']);
+
+        $summary = app(AssignDevicesToSites::class)->fromMapping(
+            $this->csv("mgmt_ip,external_ref\n10.0.2.42,inv:tower-9\n10.0.2.99,inv:tower-9\n")
+        );
+
+        $this->assertSame(1, $summary['assigned']);
+        $this->assertSame(1, $summary['unmatched_ip']); // .99 isn't a known device
+        $this->assertDatabaseHas('devices', ['id' => $device->id, 'site_id' => $site->id, 'site_source' => 'import']);
+    }
+
+    public function test_mapping_never_overrides_a_manual_placement(): void
+    {
+        $manualSite = Site::factory()->create();
+        $importSite = Site::factory()->create(['external_ref' => 'inv:other']);
+        $device = Device::factory()->create([
+            'mgmt_ip' => '10.0.2.42', 'site_id' => $manualSite->id, 'site_source' => 'manual',
+        ]);
+
+        $summary = app(AssignDevicesToSites::class)->fromMapping(
+            $this->csv("mgmt_ip,external_ref\n10.0.2.42,inv:other\n")
+        );
+
+        $this->assertSame(1, $summary['skipped_manual']);
+        $this->assertDatabaseHas('devices', ['id' => $device->id, 'site_id' => $manualSite->id]);
+    }
+
+    public function test_nearest_snaps_within_radius_and_leaves_far_devices_alone(): void
+    {
+        // Two sites ~11 km apart (0.1 deg latitude ~ 11.1 km).
+        $near = Site::factory()->at(40.0000, -100.0000)->create();
+        Site::factory()->at(40.1000, -100.0000)->create(); // ~11 km away
+
+        // Device 300 m south of $near -> inside the default 0.5 km radius.
+        $close = Device::factory()->create(['latitude' => 39.9973, 'longitude' => -100.0000]);
+        // Device 5 km away from any site -> left unassigned.
+        $far = Device::factory()->create(['latitude' => 40.0450, 'longitude' => -100.0000]);
+
+        $summary = app(AssignDevicesToSites::class)->byNearest();
+
+        $this->assertSame(1, $summary['assigned']);
+        $this->assertSame(1, $summary['too_far']);
+        $this->assertDatabaseHas('devices', ['id' => $close->id, 'site_id' => $near->id, 'site_source' => 'nearest']);
+        $this->assertDatabaseHas('devices', ['id' => $far->id, 'site_id' => null]);
+    }
+}


### PR DESCRIPTION
Reworked per the review: rebased on current main (1.5.0), the Site folded into `DeviceGeo` as a second coordinate source, and the scope cut to the parts you said you'd take now. The MapLibre renderer and the weather radar are out of this PR — they're staged as follow-ups (`pr/geo-maplibre`, `pr/geo-radar` on my fork) and I'll bring the Leaflet-vs-MapLibre numbers at my scale when I open the first one.

Three commits, each buildable and typechecked on its own:

1. **Sites** — a physical location (tower, cabinet, POP) that carries coordinates once; every device assigned to it inherits them on the geo map, so a whole tower places at once. `apiResource /api/sites`, `mymate:sites:import` CSV upsert (sites, site-to-site links, and device→site assignment — authoritative CSV or nearest-site snap). Coordinate resolution is `DeviceGeo::resolve()` only, at the extension point its docstring reserved: **own pin > site coordinates > uplink ancestor**, with ancestors themselves read as own-pin-else-site so a CPE behind a site-placed AP still lands at the tower. `Device::effectiveCoordinates()` is gone; there is one resolver.
2. **Compact geo feeds** — `GET /geo/devices` (id/name/status/site/coords/down_since only) and `GET /geo/backhauls` (site-pair coordinate lines). The full `/devices` payload is tens of MB on a big fleet; these keep the map fast. The device feed hydrates the fleet slim and runs it through the same `DeviceGeo::apply()` as the resource, so the feed can never disagree with the API about where something is — including uplink inheritance, which the earlier SQL COALESCE version missed.
3. **Leaflet: clustering, backhaul lines, layer toggles** — marker clustering (chunked loading + spiderfy) so the whole fleet renders smoothly; devices draw at their effective coordinates in the Leaflet and React Flow geo views; site-to-site backhauls draw under the markers (solid fiber / dashed wireless); Devices and Backhauls layers are switchable, remembered in localStorage via a small shared prefs module the follow-up renderers reuse.

Running against ~26k devices / ~2.8k sites here.

Tests: sites/geo/feed feature tests included (new `DeviceSiteGeoTest`, `GeoFeedsTest`, `SiteApiTest`, `SiteImportAssignTest`); full suite green on Postgres (673 passed — the two failures in my environment, `DemoCommandTest` and `ExampleTest`, fail identically on pristine upstream main there and pass in clean CI). `npx tsc --noEmit` clean.

Migrations: three additive tables/columns (`sites`, `site_links`, `devices.site_id`/`site_source`) — no changes to existing data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
