### PR TITLE
Live MTR trace to a device from the inspector (mtr --raw streamed to a live hop table)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -9,9 +9,12 @@ own for package names.
 ## What you need
 
 ```bash
-sudo apt-get install -y snmp postgresql redis-server composer \
+sudo apt-get install -y snmp mtr-tiny postgresql redis-server composer \
   php8.4-cli php8.4-pgsql php8.4-redis php8.4-snmp php8.4-mbstring php8.4-xml php8.4-bcmath php8.4-curl php8.4-intl
 ```
+
+`mtr-tiny` is what the device inspector's Trace button runs (`/usr/bin/mtr --raw`). The
+package's `mtr-packet` helper already carries `cap_net_raw`, so there's nothing to setcap.
 
 You also need Node 20 or newer (the NodeSource repo is the easy way to get it). On Debian 13
 the `sockets`, `pcntl` and `posix` extensions are already part of `php8.4-cli`, so there's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ of commit subjects.
   `redis-cli CONFIG SET maxmemory <~40% of RAM>` and `redis-cli CONFIG SET maxmemory-policy allkeys-lru`.
 
 ### Added
+- **Live path trace to a device.** A Trace button on the device inspector runs an MTR-style trace
+  from the My Mate server to the device's management IP and fills a live hop table - loss %,
+  probes sent, last/avg/best/worst/stdev latency, reverse-DNS names, colour-coded loss and a
+  latency bar - updating once a second until it finishes or you stop it. It answers "where does
+  it break?", not just "is it down?". Every operator can run one (read-only accounts included):
+  the target is always the device's own IP, so there is nothing to point somewhere else. Traces
+  run on their own `trace` Horizon queue, so a long one never delays a ping or poll sweep, and
+  closing the modal kills the mtr process. Needs the `mtr` binary on the box (Debian:
+  `apt-get install mtr-tiny`); the Docker image ships it.
 - **Sales demo: charts are full from the first click.** `mymate:demo --seed` now backfills 24 hours
   of per-minute history for every mock device - throughput, CPU/memory/temperature, and ping
   latency/loss/jitter - so the device inspector never shows "No history yet" on the demo. The

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,12 @@ FROM composer:2 AS composer
 FROM php:8.4-fpm-bookworm AS runtime
 
 # The servers we run under supervisor (openssl, for the self-signed HTTPS cert, is already
-# in the base image).
+# in the base image). mtr-tiny backs the live device trace - the distro package is fine
+# here (unlike fping we need no particular version), and its mtr-packet helper ships with
+# cap_net_raw so traces work without extra privileges.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        nginx supervisor tini postgresql-client procps libcap2-bin ca-certificates git \
+        nginx supervisor tini postgresql-client procps libcap2-bin ca-certificates git mtr-tiny \
     && rm -rf /var/lib/apt/lists/*
 
 # PHP extensions via the maintained installer - it pulls the right C libraries, builds redis

--- a/app/Http/Controllers/Api/TraceController.php
+++ b/app/Http/Controllers/Api/TraceController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\RunTraceJob;
+use App\Models\Device;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+/**
+ * Live MTR trace from this server to a device's own mgmt IP. The trace runs in
+ * RunTraceJob (isolated `trace` queue) and streams its snapshot into
+ * `Cache::get("trace:{runId}")`; this controller only starts/reads/stops that cache
+ * entry - no trace state lives in the database. It can only ever probe the device's
+ * own IP, so it's harmless for a non-admin to drive - see the exemption for these
+ * route names in RestrictWritesToAdmins.
+ */
+class TraceController extends Controller
+{
+    private const CACHE_TTL_MINUTES = 15;
+
+    /**
+     * Kick off a trace. Seeds the cache with an empty "running" snapshot before
+     * dispatching so an immediate GET (the frontend starts polling right after this
+     * returns) is a 200, not a 404 race against the queue worker picking the job up.
+     */
+    public function start(Request $request, Device $device): JsonResponse
+    {
+        if (! $device->mgmt_ip) {
+            return response()->json(['message' => 'This device has no management IP to trace.'], 422);
+        }
+
+        $rounds = max(5, min(120, (int) $request->input('rounds', 60)));
+        $runId = (string) Str::uuid();
+
+        Cache::put("trace:{$runId}", [
+            'run_id' => $runId,
+            'device_id' => $device->id,
+            'status' => 'running',
+            'target' => $device->mgmt_ip,
+            'rounds_total' => $rounds,
+            'rounds_done' => 0,
+            'error' => null,
+            'hops' => [],
+        ], now()->addMinutes(self::CACHE_TTL_MINUTES));
+
+        RunTraceJob::dispatch($device->id, $runId, $device->mgmt_ip, $rounds);
+
+        return response()->json(['run_id' => $runId, 'status' => 'running'], 202);
+    }
+
+    /** Current snapshot for a run. 404s on an unknown/expired run id or a device mismatch. */
+    public function show(Device $device, string $runId): JsonResponse
+    {
+        return response()->json(Arr::except($this->ownedSnapshot($device, $runId), ['device_id']));
+    }
+
+    /**
+     * Flags the run to stop; RunTraceJob polls this flag and exits within one poll
+     * cycle (killing the mtr process), then writes a final status=stopped snapshot.
+     */
+    public function stop(Device $device, string $runId): Response
+    {
+        $this->ownedSnapshot($device, $runId); // 404s before setting a flag for a foreign run
+
+        Cache::put("trace:{$runId}:stop", true, now()->addMinutes(self::CACHE_TTL_MINUTES));
+
+        return response()->noContent();
+    }
+
+    /** @return array<string, mixed> */
+    private function ownedSnapshot(Device $device, string $runId): array
+    {
+        $snapshot = Cache::get("trace:{$runId}");
+
+        if ($snapshot === null || (int) $snapshot['device_id'] !== $device->id) {
+            abort(404);
+        }
+
+        return $snapshot;
+    }
+}

--- a/app/Http/Middleware/RestrictWritesToAdmins.php
+++ b/app/Http/Middleware/RestrictWritesToAdmins.php
@@ -15,8 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
  * regardless of whether the UI still shows the control.
  *
  * Runs after `auth:sanctum`, so `user()` is present. Admins bypass entirely. The only
- * write a non-admin keeps is changing *their own* password (a self-service action, not a
- * change to the monitored fleet).
+ * writes a non-admin keeps are changing *their own* password (a self-service action, not
+ * a change to the monitored fleet) and the OPERATOR_ACTION_ROUTES below (harmless writes
+ * that never touch the fleet's config either).
  */
 class RestrictWritesToAdmins
 {
@@ -26,6 +27,14 @@ class RestrictWritesToAdmins
     /** Route names a non-admin may still POST/PUT to (self-service only). */
     private const SELF_SERVICE_ROUTES = ['account.password.update'];
 
+    /**
+     * Route names a non-admin may still POST/DELETE to because the action is harmless:
+     * it can only affect the requesting operator's own view, never the monitored fleet's
+     * config. Live trace start/stop is the first example - the target is locked to the
+     * device's own mgmt IP, so there's nothing here for a viewer to break.
+     */
+    private const OPERATOR_ACTION_ROUTES = ['devices.trace.start', 'devices.trace.stop'];
+
     public function handle(Request $request, Closure $next): Response
     {
         $isWrite = ! in_array($request->getMethod(), self::SAFE_METHODS, true);
@@ -33,6 +42,7 @@ class RestrictWritesToAdmins
         if ($isWrite
             && ! $request->user()?->isAdmin()
             && ! $request->routeIs(self::SELF_SERVICE_ROUTES)
+            && ! $request->routeIs(self::OPERATOR_ACTION_ROUTES)
         ) {
             abort(403, 'Read-only operator - an administrator must make this change.');
         }

--- a/app/Jobs/RunTraceJob.php
+++ b/app/Jobs/RunTraceJob.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\Trace\MtrRawParser;
+use App\Support\EngineLog;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+/**
+ * Runs one live `mtr --raw` trace to a device's mgmt IP and streams hop stats into
+ * `Cache::get("trace:{runId}")` for TraceController::show() to poll. Its own queue
+ * (`trace`) keeps a long-running interactive trace off `poll`/`ping` - an operator
+ * staring at a live table must never be the reason a metrics sweep stalls. `tries=1`:
+ * a killed/failed trace is surfaced as status=failed/stopped, never silently retried
+ * into a run the operator already closed.
+ */
+class RunTraceJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $timeout = 280;
+
+    public int $tries = 1;
+
+    /** How often a fresh snapshot is written to cache while the trace is running. */
+    private const PUSH_INTERVAL_SECONDS = 1.0;
+
+    /** Poll cadence for new process output and the stop flag. */
+    private const POLL_INTERVAL_MICROS = 250_000;
+
+    /** How long a run's snapshot survives in cache once written. */
+    private const CACHE_TTL_MINUTES = 15;
+
+    public function __construct(
+        public int $deviceId,
+        public string $runId,
+        public string $ip,
+        public int $rounds,
+    ) {
+        $this->onQueue('trace');
+    }
+
+    public function handle(): void
+    {
+        $parser = new MtrRawParser($this->ip);
+
+        try {
+            $this->run($parser);
+        } catch (Throwable $e) {
+            // A bug here (not a normal "target unreachable" mtr exit) - still leave the
+            // operator's table in a terminal state instead of stuck on "running" forever.
+            $this->push($parser, 'failed', substr($e->getMessage(), 0, 500));
+
+            throw $e; // let Horizon record the real failure
+        }
+    }
+
+    private function run(MtrRawParser $parser): void
+    {
+        // -b resolves PTR names too; -i 1 = one round per second; --raw = machine lines.
+        $process = new Process([self::binary(), '--raw', '-b', '-i', '1', '-c', (string) $this->rounds, $this->ip]);
+        $process->setTimeout(max(30, $this->timeout - 10)); // headroom under the job's own kill
+        $process->start();
+
+        $buffer = '';
+        $lastPush = 0.0;
+        $stopped = false;
+
+        while ($process->isRunning()) {
+            $buffer = $this->consume($buffer.$process->getIncrementalOutput(), $parser);
+
+            if (Cache::get("trace:{$this->runId}:stop")) {
+                $process->stop(3); // SIGTERM, then SIGKILL after 3s if it won't die
+                $stopped = true;
+                break;
+            }
+
+            $now = microtime(true);
+            if ($now - $lastPush >= self::PUSH_INTERVAL_SECONDS) {
+                $this->push($parser, 'running');
+                $lastPush = $now;
+            }
+
+            usleep(self::POLL_INTERVAL_MICROS);
+        }
+
+        // Drain whatever mtr wrote between the last read and it exiting/being killed. Any
+        // trailing fragment with no newline yet is still fed - mtr terminates every line,
+        // but this is cheap insurance against the process being killed mid-write.
+        $buffer = $this->consume($buffer.$process->getIncrementalOutput(), $parser);
+        if ($buffer !== '') {
+            $parser->feed($buffer);
+        }
+
+        Cache::forget("trace:{$this->runId}:stop");
+
+        if ($stopped) {
+            $this->push($parser, 'stopped');
+
+            return;
+        }
+
+        if ($process->isSuccessful()) {
+            $this->push($parser, 'done');
+
+            return;
+        }
+
+        $stderr = trim($process->getErrorOutput());
+        $this->push($parser, 'failed', $stderr !== '' ? substr($stderr, -500) : "mtr exited with code {$process->getExitCode()}");
+    }
+
+    /** Same resolution order as FpingRunner: explicit config, then common locations, then PATH. */
+    private static function binary(): string
+    {
+        $configured = config('mymate.trace.mtr');
+        if (is_string($configured) && $configured !== '' && is_executable($configured)) {
+            return $configured;
+        }
+        foreach (['/usr/bin/mtr', '/usr/sbin/mtr', '/usr/local/bin/mtr', '/usr/local/sbin/mtr'] as $path) {
+            if (is_executable($path)) {
+                return $path;
+            }
+        }
+
+        return 'mtr'; // last resort - relies on PATH
+    }
+
+    /** Feeds every complete line to the parser, returning the unfinished remainder. */
+    private function consume(string $buffer, MtrRawParser $parser): string
+    {
+        while (($pos = strpos($buffer, "\n")) !== false) {
+            $parser->feed(substr($buffer, 0, $pos));
+            $buffer = substr($buffer, $pos + 1);
+        }
+
+        return $buffer;
+    }
+
+    private function push(MtrRawParser $parser, string $status, ?string $error = null): void
+    {
+        $snapshot = $parser->snapshot();
+
+        Cache::put("trace:{$this->runId}", [
+            'run_id' => $this->runId,
+            'device_id' => $this->deviceId,
+            'status' => $status,
+            'target' => $this->ip,
+            'rounds_total' => $this->rounds,
+            'rounds_done' => $snapshot['rounds_done'],
+            'error' => $error,
+            'hops' => $snapshot['hops'],
+        ], now()->addMinutes(self::CACHE_TTL_MINUTES));
+    }
+
+    public function failed(Throwable $e): void
+    {
+        EngineLog::error('trace: job failed', [
+            'device_id' => $this->deviceId,
+            'run_id' => $this->runId,
+            'exception' => $e::class,
+            'error' => $e->getMessage(),
+        ]);
+    }
+}

--- a/app/Services/Trace/MtrRawParser.php
+++ b/app/Services/Trace/MtrRawParser.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Services\Trace;
+
+/**
+ * Turns `mtr --raw -b` stdout lines into the per-hop stats the trace API exposes
+ * (sent/recv/loss + last/avg/best/worst/stdev latency in ms). Feed it lines as they
+ * arrive from the running process - it holds all state so RunTraceJob can pull a
+ * fresh snapshot() every ~second without re-parsing anything already seen.
+ *
+ * Raw grammar (mtr-tiny 0.95, `mtr --raw -b -i 1 -c <rounds> <ip>`):
+ *   x <ttl> <seq>          probe sent for hop <ttl>
+ *   h <ttl> <ip>           responder address for hop <ttl> (repeats - idempotent to set)
+ *   p <ttl> <usec> <seq>   round-trip time in MICROSECONDS for hop <ttl>
+ *   d <ttl> <hostname>     lazy reverse-DNS name for hop <ttl> (may never arrive)
+ * ttl 0 is the source (mtr itself), never part of the reported path - ignored.
+ */
+class MtrRawParser
+{
+    /**
+     * Per-ttl running stats. mean/m2 are Welford's online-variance accumulators
+     * (avoids keeping every sample just to compute avg/stdev).
+     *
+     * @var array<int, array{ip: ?string, ptr: ?string, sent: int, recv: int, last: ?float, best: ?float, worst: ?float, mean: float, m2: float}>
+     */
+    private array $hops = [];
+
+    /** Count of `x 1 ...` lines - the number of rounds mtr has started firing probes for. */
+    private int $roundsDone = 0;
+
+    /** Highest ttl seen in any `x`/`h`/`p`/`d` line so far. */
+    private int $maxTtl = 0;
+
+    public function __construct(private readonly string $target)
+    {
+    }
+
+    public function feed(string $line): void
+    {
+        $line = trim($line);
+        if ($line === '') {
+            return;
+        }
+
+        $parts = preg_split('/\s+/', $line);
+        if ($parts === false || count($parts) < 2) {
+            return; // not a line shape we understand - ignore rather than blow up mid-stream
+        }
+
+        $ttl = (int) $parts[1];
+        if ($ttl < 1) {
+            return; // ttl 0 = source hop, or an unparsable ttl - not part of the reported path
+        }
+
+        $this->maxTtl = max($this->maxTtl, $ttl);
+
+        match ($parts[0]) {
+            'x' => $this->onSent($ttl),
+            'h' => $this->onAddress($ttl, $parts[2] ?? null),
+            'p' => $this->onRtt($ttl, $parts[2] ?? null),
+            'd' => $this->onPtr($ttl, $parts[2] ?? null),
+            default => null, // unhandled raw line type (future mtr additions, event lines, ...)
+        };
+    }
+
+    /**
+     * Current view of the run: hop stats plus rounds_done, matching the API contract's
+     * `hops` array. Collapses the trailing-target artifact (see targetCutoff()) so a
+     * caller never has to know about mtr's path-length hunting.
+     *
+     * @return array{rounds_done: int, hops: list<array<string, mixed>>}
+     */
+    public function snapshot(): array
+    {
+        $cutoff = $this->targetCutoff();
+
+        $hops = [];
+        for ($ttl = 1; $ttl <= $cutoff; $ttl++) {
+            $hops[] = $this->hopSnapshot($ttl, $this->hops[$ttl] ?? null);
+        }
+
+        return ['rounds_done' => $this->roundsDone, 'hops' => $hops];
+    }
+
+    private function onSent(int $ttl): void
+    {
+        $hop = &$this->hop($ttl);
+        $hop['sent']++;
+
+        if ($ttl === 1) {
+            $this->roundsDone++;
+        }
+    }
+
+    private function onAddress(int $ttl, ?string $ip): void
+    {
+        if ($ip === null) {
+            return;
+        }
+
+        $hop = &$this->hop($ttl);
+        $hop['ip'] = $ip; // repeated 'h' lines for the same hop just re-confirm it - idempotent
+    }
+
+    private function onPtr(int $ttl, ?string $hostname): void
+    {
+        if ($hostname === null) {
+            return;
+        }
+
+        $hop = &$this->hop($ttl);
+        $hop['ptr'] = $hostname;
+    }
+
+    private function onRtt(int $ttl, ?string $usec): void
+    {
+        if ($usec === null || ! is_numeric($usec)) {
+            return;
+        }
+
+        $ms = ((float) $usec) / 1000.0;
+
+        $hop = &$this->hop($ttl);
+        $hop['recv']++;
+        $hop['last'] = $ms;
+        $hop['best'] = $hop['best'] === null ? $ms : min($hop['best'], $ms);
+        $hop['worst'] = $hop['worst'] === null ? $ms : max($hop['worst'], $ms);
+
+        // Welford's online algorithm - avg/variance in one pass, no stored sample list.
+        $delta = $ms - $hop['mean'];
+        $hop['mean'] += $delta / $hop['recv'];
+        $hop['m2'] += $delta * ($ms - $hop['mean']);
+    }
+
+    /** @return array{ip: ?string, ptr: ?string, sent: int, recv: int, last: ?float, best: ?float, worst: ?float, mean: float, m2: float} */
+    private function &hop(int $ttl): array
+    {
+        if (! isset($this->hops[$ttl])) {
+            $this->hops[$ttl] = [
+                'ip' => null, 'ptr' => null, 'sent' => 0, 'recv' => 0,
+                'last' => null, 'best' => null, 'worst' => null, 'mean' => 0.0, 'm2' => 0.0,
+            ];
+        }
+
+        return $this->hops[$ttl];
+    }
+
+    /**
+     * mtr grows the probed ttl range while it hunts for the path length, so the target's
+     * own IP can show up at more than one trailing ttl (e.g. ttl 8 *and* 9 both answering
+     * as the final destination in the same run). The first ttl the target answers at IS
+     * the real path length - anything past it is that hunting artifact, not a real hop.
+     * Returns maxTtl unchanged when the target hasn't answered yet (or never does).
+     */
+    private function targetCutoff(): int
+    {
+        for ($ttl = 1; $ttl <= $this->maxTtl; $ttl++) {
+            if (($this->hops[$ttl]['ip'] ?? null) === $this->target) {
+                return $ttl;
+            }
+        }
+
+        return $this->maxTtl;
+    }
+
+    /**
+     * @param ?array{ip: ?string, ptr: ?string, sent: int, recv: int, last: ?float, best: ?float, worst: ?float, mean: float, m2: float} $hop
+     * @return array<string, mixed>
+     */
+    private function hopSnapshot(int $ttl, ?array $hop): array
+    {
+        $sent = $hop['sent'] ?? 0;
+        $recv = $hop['recv'] ?? 0;
+        $answered = $recv > 0; // a hop that never answered reports null ip/ptr/latency, 100% loss
+
+        return [
+            'ttl' => $ttl,
+            'ip' => $answered ? $hop['ip'] : null,
+            'ptr' => $answered ? $hop['ptr'] : null,
+            'sent' => $sent,
+            'recv' => $recv,
+            'loss_pct' => $sent > 0 ? round((1 - $recv / $sent) * 100, 1) : 100.0,
+            'last_ms' => $answered ? round($hop['last'], 1) : null,
+            'avg_ms' => $answered ? round($hop['mean'], 1) : null,
+            'best_ms' => $answered ? round($hop['best'], 1) : null,
+            'worst_ms' => $answered ? round($hop['worst'], 1) : null,
+            // Population stdev over the received samples (matches mtr's own STDEV column).
+            'stdev_ms' => $answered ? round($recv > 1 ? sqrt($hop['m2'] / $recv) : 0.0, 1) : null,
+        ];
+    }
+}

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -286,6 +286,24 @@ return [
             'nice' => 0,
         ],
 
+        // Live MTR traces: isolated queue + single process by default so a live trace an
+        // operator forgot to close can't starve pings/polls of workers.
+        // tries=1 - a killed/failed trace is surfaced as status=failed/stopped, never
+        // silently retried into a run the operator already closed.
+        'supervisor-trace' => [
+            'connection' => 'redis',
+            'queue' => ['trace'],
+            'balance' => 'auto',
+            'autoScalingStrategy' => 'time',
+            'maxProcesses' => 1,
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 128,
+            'tries' => 1,
+            'timeout' => 300,
+            'nice' => 0,
+        ],
+
         // Dude imports (FR-Dude): isolated + long timeout - extraction (Python) plus
         // upserting millions of history rows must never block polling/discovery.
         'supervisor-import' => [
@@ -313,6 +331,7 @@ return [
             'supervisor-scan' => ['maxProcesses' => 4],
             'supervisor-upgrade' => ['maxProcesses' => 4],
             'supervisor-backup' => ['maxProcesses' => 3],
+            'supervisor-trace' => ['maxProcesses' => 3],
             'supervisor-import' => ['maxProcesses' => 1],
         ],
 
@@ -322,6 +341,7 @@ return [
             'supervisor-scan' => ['maxProcesses' => 1],
             'supervisor-upgrade' => ['maxProcesses' => 1],
             'supervisor-backup' => ['maxProcesses' => 1],
+            'supervisor-trace' => ['maxProcesses' => 1],
             'supervisor-import' => ['maxProcesses' => 1],
         ],
     ],

--- a/config/mymate.php
+++ b/config/mymate.php
@@ -48,6 +48,13 @@ return [
         'fail_threshold' => max(1, (int) env('MYMATE_PING_FAIL_THRESHOLD', 3)),
     ],
 
+    // Live MTR traces (the device inspector's Trace button).
+    'trace' => [
+        // Path to the mtr binary. Null = auto-detect (common bin/sbin locations, then PATH).
+        // Set explicitly if mtr lives somewhere unusual.
+        'mtr' => env('MYMATE_MTR_PATH'),
+    ],
+
     // Interface throughput loop. intervals in seconds.
     'poll' => [
         'interval' => (int) env('MYMATE_POLL_INTERVAL', 12),

--- a/resources/js/features/topology/api/deviceTrace.ts
+++ b/resources/js/features/topology/api/deviceTrace.ts
@@ -1,0 +1,91 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { apiClient } from '../../../lib/apiClient';
+
+/** One row of the trace: a TTL and whatever answered at it. A hop that never replied
+ *  keeps its ttl but has no address and null latency (loss_pct 100) - the classic
+ *  MTR "* * *" line, which we render as a placeholder rather than dropping. */
+export interface TraceHop {
+    ttl: number;
+    ip: string | null;
+    ptr: string | null;
+    sent: number;
+    recv: number;
+    loss_pct: number;
+    last_ms: number | null;
+    avg_ms: number | null;
+    best_ms: number | null;
+    worst_ms: number | null;
+    stdev_ms: number | null;
+}
+
+export type TraceStatus = 'running' | 'done' | 'failed' | 'stopped';
+
+/** A snapshot of a trace run. The backend rewrites this at most once a second while
+ *  mtr streams, so every poll is a complete picture - no client-side accumulation. */
+export interface TraceRun {
+    run_id: string;
+    status: TraceStatus;
+    target: string;
+    rounds_total: number;
+    rounds_done: number;
+    error: string | null;
+    hops: TraceHop[];
+}
+
+/** What POST /trace hands back: the id to poll. */
+export interface TraceStarted {
+    run_id: string;
+    status: TraceStatus;
+}
+
+// Query keys for a single trace run's snapshot.
+export const traceKeys = {
+    all: ['device-trace'] as const,
+    run: (deviceId: number, runId: string) => [...traceKeys.all, deviceId, runId] as const,
+};
+
+/** Kick off a trace from the MyMate server to the device's mgmt IP. The target is chosen
+ *  server-side from the device, so there is nothing to aim here - only how long to run. */
+export function useStartTrace() {
+    return useMutation({
+        mutationFn: async ({ deviceId, rounds }: { deviceId: number; rounds?: number }): Promise<TraceStarted> => {
+            const { data } = await apiClient.post<TraceStarted>(
+                `/devices/${deviceId}/trace`,
+                rounds === undefined ? {} : { rounds },
+            );
+            return data;
+        },
+    });
+}
+
+async function fetchTraceRun(deviceId: number, runId: string): Promise<TraceRun> {
+    const { data } = await apiClient.get<TraceRun>(`/devices/${deviceId}/trace/${runId}`);
+    return data;
+}
+
+/**
+ * Poll a run's snapshot once a second while it is running, then stop dead - a finished
+ * run is immutable, so continuing to poll would just burn requests (and the cached
+ * snapshot expires server-side anyway). A 404 means the run expired or belongs to
+ * another device; retrying that never helps, so it surfaces as an error immediately.
+ */
+export function useTraceRun(deviceId: number | null, runId: string | null) {
+    return useQuery({
+        queryKey: traceKeys.run(deviceId ?? 0, runId ?? ''),
+        queryFn: () => fetchTraceRun(deviceId as number, runId as string),
+        enabled: deviceId !== null && runId !== null,
+        refetchInterval: (query) => (query.state.data?.status === 'running' ? 1000 : false),
+        retry: false,
+        gcTime: 0, // each run id is used once; don't keep dead snapshots around
+    });
+}
+
+/**
+ * Fire-and-forget stop, for the modal closing/unmounting mid-run: the job can otherwise
+ * keep an mtr process alive for another minute or two on a queue with one worker. Errors
+ * are swallowed deliberately - by the time this fires the component is already gone, and
+ * a run that already finished 404s harmlessly.
+ */
+export function stopTrace(deviceId: number, runId: string): void {
+    void apiClient.delete(`/devices/${deviceId}/trace/${runId}`).catch(() => undefined);
+}

--- a/resources/js/features/topology/components/DeviceInspector.tsx
+++ b/resources/js/features/topology/components/DeviceInspector.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { ArrowsOut, CaretDown, CaretLeft, CaretRight, Check, CircleNotch, LinkSimple, MagnifyingGlass, PencilSimple, Terminal, Trash, X } from '@phosphor-icons/react';
+import { ArrowsOut, CaretDown, CaretLeft, CaretRight, Check, CircleNotch, LinkSimple, MagnifyingGlass, Path, PencilSimple, Terminal, Trash, X } from '@phosphor-icons/react';
 import {
     useSelectedDeviceId,
     selectDevice,
@@ -25,6 +25,7 @@ import { LinkHistoryDialog } from './LinkHistoryDialog';
 import { AddLinkDialog } from './LinkBinderDialog';
 import { DeviceDialog } from '../../devices/components/DeviceDialog';
 import { ChartModal } from './ChartModal';
+import { TraceModal } from './TraceModal';
 import { BackupSection } from '../../backups/components/BackupSection';
 import { DeviceResources } from './DeviceResources';
 import { ConfirmDialog } from '../../../components/Dialog';
@@ -484,6 +485,7 @@ export function DeviceInspector() {
     const [deletingLink, setDeletingLink] = useState<{ id: number; label: string } | null>(null);
     const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
     const [chartExpanded, setChartExpanded] = useState(false);
+    const [tracing, setTracing] = useState(false);
     const activeMapId = useActiveMapId();
     const { data: mapDetail } = useMap(activeMapId);
     const addToMap = useAddDeviceToMap();
@@ -623,6 +625,14 @@ export function DeviceInspector() {
                 <a href={`ssh://${device.mgmt_ip}`} className={actionBtn}>
                     <Terminal weight="light" className="h-3.5 w-3.5" /> SSH
                 </a>
+                {/* Path trace from the MyMate server to this device - read-only, so every operator gets it. */}
+                <button
+                    onClick={() => setTracing(true)}
+                    title="Live hop-by-hop trace from this server to the device (MTR)"
+                    className={actionBtn}
+                >
+                    <Path weight="light" className="h-3.5 w-3.5" /> Trace
+                </button>
                 {isAdmin && (
                     <button
                         onClick={doUpgrade}
@@ -862,6 +872,16 @@ export function DeviceInspector() {
                     deviceName={device.name}
                     hasSpeed={allHaveSpeed}
                     onClose={() => setChartExpanded(false)}
+                />
+            )}
+
+            {/* Live MTR trace to this device's mgmt IP; the run is stopped when this closes. */}
+            {tracing && (
+                <TraceModal
+                    deviceId={device.id}
+                    deviceName={device.name}
+                    targetIp={device.mgmt_ip}
+                    onClose={() => setTracing(false)}
                 />
             )}
 

--- a/resources/js/features/topology/components/TraceModal.tsx
+++ b/resources/js/features/topology/components/TraceModal.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ArrowClockwise, CircleNotch, Path, Stop, WarningCircle, X } from '@phosphor-icons/react';
+import { stopTrace, useStartTrace, useTraceRun, type TraceHop, type TraceRun } from '../api/deviceTrace';
+
+const DEFAULT_ROUNDS = 60;
+const ROUND_CHOICES = [20, 60, 120];
+
+// Sub-millisecond precision only matters on the near hops; past 100 ms the decimal is noise.
+function fmtMs(ms: number | null): string {
+    if (ms === null) return '-';
+    return ms >= 100 ? ms.toFixed(0) : ms.toFixed(1);
+}
+
+// Loss ramp: clean / degraded / bad. A single dropped probe out of sixty is normal on
+// rate-limited routers, so only sustained loss goes red.
+function lossClass(hop: TraceHop): string {
+    if (hop.sent === 0) return 'text-white/25';
+    if (hop.loss_pct <= 0) return 'text-emerald-300';
+    if (hop.loss_pct < 20) return 'text-amber-300';
+    return 'text-rose-300';
+}
+
+// The latency bar is scaled to the slowest hop in this trace, so the shape of the path
+// (where the jump happens) reads at a glance instead of having to compare numbers.
+function barClass(ratio: number): string {
+    if (ratio < 0.34) return 'bg-emerald-400/25';
+    if (ratio < 0.67) return 'bg-amber-400/25';
+    return 'bg-rose-400/25';
+}
+
+const th = 'whitespace-nowrap px-3 py-2 text-right font-medium';
+const td = 'whitespace-nowrap px-3 py-1.5 text-right font-mono tabular-nums';
+
+const ctrlBtn =
+    'inline-flex items-center justify-center gap-1.5 rounded-lg bg-white/[0.04] px-2.5 py-1.5 text-xs font-medium text-white/75 ring-1 ring-white/10 transition-all duration-300 ease-fluid hover:bg-white/[0.08] hover:text-white disabled:cursor-not-allowed disabled:opacity-40';
+
+/** Host cell: the PTR name when mtr resolved one, the address underneath it in mono.
+ *  A hop that never answered keeps its slot as MTR's pulsing `* * *` - dropping the row
+ *  would silently renumber the path. */
+function HostCell({ hop, isTarget }: { hop: TraceHop; isTarget: boolean }) {
+    if (hop.ip === null) {
+        return (
+            <span className="flex items-center gap-2">
+                <span className="animate-pulse font-mono text-white/25">* * *</span>
+                <span className="text-[11px] text-white/25">no response</span>
+            </span>
+        );
+    }
+    return (
+        // max-w keeps a long PTR name from stretching the table past the modal - a table
+        // cell won't clip on its own, the flex box has to.
+        <span className="flex min-w-0 max-w-[18rem] items-center gap-2">
+            <span className="min-w-0">
+                {hop.ptr ? (
+                    <>
+                        <span className="block truncate text-white/85">{hop.ptr}</span>
+                        <span className="block truncate font-mono text-[11px] text-white/35">{hop.ip}</span>
+                    </>
+                ) : (
+                    <span className="block truncate font-mono text-white/80">{hop.ip}</span>
+                )}
+            </span>
+            {isTarget && (
+                <span className="shrink-0 rounded-full bg-emerald-400/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-300 ring-1 ring-emerald-400/20">
+                    target
+                </span>
+            )}
+        </span>
+    );
+}
+
+function HopTable({ run }: { run: TraceRun }) {
+    // Bar scale: the slowest average in the table. Guarded so an all-timeout trace
+    // doesn't divide by zero.
+    const maxAvg = run.hops.reduce((m, h) => Math.max(m, h.avg_ms ?? 0), 0) || 1;
+
+    return (
+        // One scroll container for both axes - the table is wider than a phone, and the
+        // sticky header only works against the box that actually scrolls.
+        <div className="max-h-[62vh] overflow-auto rounded-xl ring-1 ring-white/[0.06]">
+            <table className="w-full min-w-[44rem] text-left text-sm">
+                <thead className="sticky top-0 z-10 bg-[#15151b] text-[10px] uppercase tracking-[0.16em] text-white/35">
+                    <tr>
+                        <th className="w-10 whitespace-nowrap px-3 py-2 text-right font-medium">#</th>
+                        <th className="whitespace-nowrap px-3 py-2 font-medium">Host</th>
+                        <th className={th}>Loss%</th>
+                        <th className={th}>Snt</th>
+                        <th className={th}>Last</th>
+                        <th className={th}>Avg</th>
+                        <th className={th}>Best</th>
+                        <th className={th}>Wrst</th>
+                        <th className={th}>StDev</th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-white/[0.04]">
+                    {run.hops.map((hop) => {
+                        const isTarget = hop.ip !== null && hop.ip === run.target;
+                        const ratio = (hop.avg_ms ?? 0) / maxAvg;
+                        return (
+                            <tr
+                                key={hop.ttl}
+                                className={`transition-colors duration-200 hover:bg-white/[0.03] ${
+                                    isTarget ? 'bg-emerald-400/[0.04]' : ''
+                                }`}
+                            >
+                                <td className="whitespace-nowrap px-3 py-1.5 text-right font-mono tabular-nums text-white/30">
+                                    {hop.ttl}
+                                </td>
+                                <td className="px-3 py-1.5">
+                                    <HostCell hop={hop} isTarget={isTarget} />
+                                </td>
+                                <td className={`${td} ${lossClass(hop)}`}>{hop.loss_pct.toFixed(hop.loss_pct % 1 === 0 ? 0 : 1)}</td>
+                                <td className={`${td} text-white/45`}>{hop.sent}</td>
+                                <td className={`${td} text-white/70`}>{fmtMs(hop.last_ms)}</td>
+                                {/* Avg carries the bar: it's the number an operator scans down the column. */}
+                                <td className={`relative ${td} text-white/90`}>
+                                    <span
+                                        aria-hidden
+                                        className={`absolute inset-y-[3px] left-0 rounded-sm ${barClass(ratio)}`}
+                                        style={{ width: `${Math.max(hop.avg_ms === null ? 0 : 4, ratio * 100)}%` }}
+                                    />
+                                    <span className="relative">{fmtMs(hop.avg_ms)}</span>
+                                </td>
+                                <td className={`${td} text-white/45`}>{fmtMs(hop.best_ms)}</td>
+                                <td className={`${td} text-white/45`}>{fmtMs(hop.worst_ms)}</td>
+                                <td className={`${td} text-white/45`}>{fmtMs(hop.stdev_ms)}</td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+/**
+ * Live MTR-style path trace from the MyMate server to a device's mgmt IP. Starts a run on
+ * mount and polls its snapshot once a second; closing the modal stops the run server-side
+ * so an abandoned trace doesn't hold the single trace worker for another minute.
+ */
+export function TraceModal({
+    deviceId,
+    deviceName,
+    targetIp,
+    onClose,
+}: {
+    deviceId: number;
+    deviceName: string;
+    targetIp: string;
+    onClose: () => void;
+}) {
+    const [rounds, setRounds] = useState(DEFAULT_ROUNDS);
+    const [runId, setRunId] = useState<string | null>(null);
+    const start = useStartTrace();
+    const { data: run, error: pollError } = useTraceRun(deviceId, runId);
+
+    // "In flight" spans the whole gap from pressing the button to the final snapshot:
+    // the POST, the wait for the first poll, and the run itself. Without the middle case
+    // the controls would flicker back to "Run again" for a second right after starting.
+    const awaitingFirstPoll = runId !== null && run === undefined && pollError === null;
+    const running = start.isPending || awaitingFirstPoll || run?.status === 'running';
+
+    // The unmount cleanup needs the *current* run, but must not re-run on every poll -
+    // a ref keeps the effect's dependency list empty while still seeing the latest ids.
+    const activeRef = useRef<{ runId: string; running: boolean } | null>(null);
+    useEffect(() => {
+        activeRef.current =
+            runId === null ? null : { runId, running: run === undefined || run.status === 'running' };
+    }, [runId, run]);
+
+    const startMutate = start.mutate;
+    const startRun = useCallback(
+        (nextRounds: number): void => {
+            const previous = activeRef.current;
+            if (previous?.running) stopTrace(deviceId, previous.runId); // never leave two runs queued
+            setRunId(null);
+            startMutate({ deviceId, rounds: nextRounds }, { onSuccess: (started) => setRunId(started.run_id) });
+        },
+        [deviceId, startMutate],
+    );
+
+    function stopNow(): void {
+        if (runId !== null) stopTrace(deviceId, runId);
+    }
+
+    // Start as soon as the modal opens - the operator asked for a trace by opening it.
+    // The ref guard keeps StrictMode's double-invoked mount effect from queueing two runs.
+    const startedRef = useRef(false);
+    useEffect(() => {
+        if (startedRef.current) return;
+        startedRef.current = true;
+        startRun(DEFAULT_ROUNDS);
+    }, [startRun]);
+
+    // Stop the server-side run when the modal goes away mid-trace.
+    useEffect(
+        () => () => {
+            const active = activeRef.current;
+            if (active?.running) stopTrace(deviceId, active.runId);
+        },
+        [deviceId],
+    );
+
+    // Esc closes, matching the app's other dialogs.
+    useEffect(() => {
+        function onKey(e: KeyboardEvent): void {
+            if (e.key === 'Escape') onClose();
+        }
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [onClose]);
+
+    const target = run?.target ?? targetIp;
+    const total = run?.rounds_total ?? rounds;
+    const failure = run?.status === 'failed' ? run.error ?? 'The trace failed.' : null;
+    const startFailed = start.isError;
+
+    const statusLine =
+        startFailed
+            ? 'Couldn\'t start the trace'
+            : run?.status === 'done'
+              ? `Complete - ${run.rounds_done} rounds, ${run.hops.length} hops`
+              : run?.status === 'stopped'
+                ? `Stopped after ${run.rounds_done} rounds`
+                : run?.status === 'failed'
+                  ? 'Failed'
+                  : run
+                    ? `Probing - round ${run.rounds_done} of ${total}`
+                    : 'Starting mtr...';
+
+    // Portalled to <body> like the chart modal: the inspector panel is transformed, which
+    // would otherwise clip a fixed-position child.
+    return createPortal(
+        <div className="fixed inset-0 z-[60] grid place-items-center p-4 sm:p-8">
+            <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
+
+            <div className="animate-rise relative w-full max-w-4xl rounded-[1.5rem] bg-white/[0.05] p-1 shadow-[0_30px_80px_-20px_rgba(0,0,0,0.9)] ring-1 ring-white/10">
+                <div className="relative flex flex-col gap-4 rounded-[calc(1.5rem-0.25rem)] bg-[#0d0d11] p-6 ring-1 ring-white/10">
+                    <button
+                        onClick={onClose}
+                        aria-label="Close"
+                        className="absolute right-4 top-4 z-10 rounded-lg p-1 text-white/40 transition-colors duration-300 ease-fluid hover:bg-white/5 hover:text-white/80"
+                    >
+                        <X weight="bold" className="h-5 w-5" />
+                    </button>
+
+                    <header className="flex flex-wrap items-start justify-between gap-3 pr-10">
+                        <div className="flex min-w-0 items-center gap-3">
+                            <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-400/20">
+                                <Path weight="light" className="h-5 w-5" />
+                            </span>
+                            <div className="min-w-0">
+                                <h2 className="truncate text-base font-bold tracking-tight text-white">Trace</h2>
+                                <p className="truncate text-xs text-white/40">
+                                    {deviceName} <span className="text-white/25">-</span>{' '}
+                                    <span className="font-mono text-white/55">{target}</span>
+                                </p>
+                            </div>
+                        </div>
+                        <span className="flex items-center gap-1.5 font-mono text-xs tabular-nums text-white/45">
+                            {running && <CircleNotch weight="bold" className="h-3.5 w-3.5 animate-spin text-emerald-300" />}
+                            {run ? run.rounds_done : 0}/{total}
+                        </span>
+                    </header>
+
+                    {(failure !== null || startFailed) && (
+                        <div className="flex items-start gap-2 rounded-xl bg-rose-500/10 px-3 py-2.5 text-xs text-rose-200 ring-1 ring-rose-400/20">
+                            <WarningCircle weight="light" className="mt-px h-4 w-4 shrink-0" />
+                            <span className="min-w-0 break-words">
+                                {startFailed ? 'Couldn\'t start the trace - the server refused the request.' : failure}
+                            </span>
+                        </div>
+                    )}
+
+                    {pollError !== null && !startFailed && (
+                        <div className="flex items-start gap-2 rounded-xl bg-white/[0.03] px-3 py-2.5 text-xs text-white/50 ring-1 ring-white/[0.06]">
+                            <WarningCircle weight="light" className="mt-px h-4 w-4 shrink-0" />
+                            This trace is no longer available - run it again for a fresh path.
+                        </div>
+                    )}
+
+                    {run && run.hops.length > 0 ? (
+                        <HopTable run={run} />
+                    ) : (
+                        // The first poll can land before mtr has transmitted anything - say so
+                        // rather than flashing an empty table.
+                        <div className="grid place-items-center rounded-xl bg-white/[0.02] py-16 text-center ring-1 ring-white/[0.06]">
+                            <p className="flex items-center gap-2 text-sm text-white/40">
+                                {running && <CircleNotch weight="bold" className="h-4 w-4 animate-spin" />}
+                                {failure ?? (startFailed ? 'Nothing to show.' : 'Waiting for the first hop...')}
+                            </p>
+                        </div>
+                    )}
+
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                        <p className="text-[11px] tabular-nums text-white/35">{statusLine}</p>
+                        <div className="flex items-center gap-2">
+                            {/* Round count is fixed for the life of a run - pick it before the next one. */}
+                            <div className="flex items-center gap-0.5 rounded-full bg-white/5 p-0.5 text-[11px] ring-1 ring-white/10">
+                                {ROUND_CHOICES.map((r) => (
+                                    <button
+                                        key={r}
+                                        onClick={() => setRounds(r)}
+                                        disabled={running}
+                                        title={`${r} probe rounds (roughly ${r} seconds)`}
+                                        className={`rounded-full px-2.5 py-0.5 tabular-nums transition-colors duration-300 disabled:opacity-40 ${
+                                            rounds === r ? 'bg-white/10 text-white/90' : 'text-white/40 hover:text-white/70'
+                                        }`}
+                                    >
+                                        {r}
+                                    </button>
+                                ))}
+                            </div>
+                            {running ? (
+                                <button onClick={stopNow} className={ctrlBtn} disabled={runId === null}>
+                                    <Stop weight="fill" className="h-3.5 w-3.5" /> Stop
+                                </button>
+                            ) : (
+                                <button onClick={() => startRun(rounds)} className={ctrlBtn} disabled={start.isPending}>
+                                    <ArrowClockwise weight="bold" className="h-3.5 w-3.5" /> Run again
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>,
+        document.body,
+    );
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -138,6 +138,15 @@ Route::middleware(['auth:sanctum', RestrictWritesToAdmins::class])->group(functi
     // Recent history: bucketed latency/loss/jitter series for one device (ping chart).
     Route::get('devices/{device}/ping-samples', [InterfaceSampleController::class, 'ping'])
         ->name('devices.ping-samples');
+    // Live MTR trace from this server to a device's own mgmt IP. start/stop are
+    // non-admin-safe (see RestrictWritesToAdmins::OPERATOR_ACTION_ROUTES) - the target
+    // is locked to the device's own IP, so there's nothing here for an operator to break.
+    Route::post('devices/{device}/trace', [\App\Http\Controllers\Api\TraceController::class, 'start'])
+        ->name('devices.trace.start');
+    Route::get('devices/{device}/trace/{runId}', [\App\Http\Controllers\Api\TraceController::class, 'show'])
+        ->name('devices.trace.show');
+    Route::delete('devices/{device}/trace/{runId}', [\App\Http\Controllers\Api\TraceController::class, 'stop'])
+        ->name('devices.trace.stop');
     // Device model icon (MikroTik product photo, fetched + cached on first sighting).
     Route::get('devices/{device}/icon', [\App\Http\Controllers\Api\DeviceIconController::class, 'show'])
         ->name('devices.icon');

--- a/tests/Unit/MtrRawParserTest.php
+++ b/tests/Unit/MtrRawParserTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\Trace\MtrRawParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * MtrRawParser is a pure class (no framework deps), so this is a plain PHPUnit test -
+ * no need to boot the app. Feeds a real `mtr --raw -b -c 1 1.1.1.1` capture (the transit
+ * hops rewritten to RFC 5737 documentation addresses) and asserts the accounting plus
+ * the trailing-target collapse.
+ */
+class MtrRawParserTest extends TestCase
+{
+    /** @var list<string> */
+    private const SAMPLE_CAPTURE = [
+        'x 0 33000',
+        'x 1 33001',
+        'h 1 192.0.2.1',
+        'h 1 192.0.2.1',
+        'p 1 1790 33001',
+        'x 2 33002',
+        'h 2 192.0.2.129',
+        'h 2 192.0.2.129',
+        'p 2 2714 33002',
+        'x 3 33003',
+        'h 3 198.51.100.9',
+        'p 3 17478 33003',
+        'x 4 33004',
+        'x 5 33005',
+        'x 6 33006',
+        'h 6 198.51.100.42',
+        'p 6 15877 33006',
+        'x 7 33007',
+        'h 7 203.0.113.7',
+        'p 7 43077 33007',
+        'x 8 33008',
+        'h 8 1.1.1.1',
+        'p 8 17688 33008',
+        'x 9 33009',
+        'h 9 1.1.1.1',
+        'd 9 one.one.one.one',
+        'p 9 15900 33009',
+    ];
+
+    public function test_collapses_trailing_target_duplicate_and_counts_one_round(): void
+    {
+        $snapshot = $this->parseSample();
+
+        $this->assertSame(1, $snapshot['rounds_done']);
+        // ttl 9 also answers as 1.1.1.1, but that's mtr's path-length-hunting artifact -
+        // ttl 8 was the first hit, so ttl 9 must not appear in the reported path at all.
+        $this->assertCount(8, $snapshot['hops']);
+        $this->assertSame(8, $snapshot['hops'][7]['ttl']);
+        $this->assertSame('1.1.1.1', $snapshot['hops'][7]['ip']);
+    }
+
+    public function test_answered_hop_stats(): void
+    {
+        $hops = $this->parseSample()['hops'];
+
+        $hop1 = $hops[0];
+        $this->assertSame(1, $hop1['ttl']);
+        $this->assertSame('192.0.2.1', $hop1['ip']);
+        $this->assertSame(1, $hop1['sent']);
+        $this->assertSame(1, $hop1['recv']);
+        $this->assertSame(0.0, $hop1['loss_pct']);
+        // 1790us -> 1.79ms, rounded to 1 decimal; single sample so last=avg=best=worst, stdev=0.
+        $this->assertSame(1.8, $hop1['last_ms']);
+        $this->assertSame(1.8, $hop1['avg_ms']);
+        $this->assertSame(1.8, $hop1['best_ms']);
+        $this->assertSame(1.8, $hop1['worst_ms']);
+        $this->assertSame(0.0, $hop1['stdev_ms']);
+
+        $hop8 = $hops[7];
+        $this->assertSame('1.1.1.1', $hop8['ip']);
+        $this->assertSame(17.7, $hop8['last_ms']); // 17688us -> 17.688ms
+    }
+
+    public function test_unanswered_hop_reports_null_ip_and_full_loss(): void
+    {
+        $hops = $this->parseSample()['hops'];
+
+        // ttl 4 was probed (x 4) but never answered (no h/p) - a dropped-probe hop,
+        // distinct from a hop that was never reached at all.
+        $hop4 = $hops[3];
+        $this->assertSame(4, $hop4['ttl']);
+        $this->assertNull($hop4['ip']);
+        $this->assertNull($hop4['ptr']);
+        $this->assertSame(1, $hop4['sent']);
+        $this->assertSame(0, $hop4['recv']);
+        $this->assertSame(100.0, $hop4['loss_pct']);
+        $this->assertNull($hop4['last_ms']);
+        $this->assertNull($hop4['avg_ms']);
+        $this->assertNull($hop4['best_ms']);
+        $this->assertNull($hop4['worst_ms']);
+        $this->assertNull($hop4['stdev_ms']);
+    }
+
+    public function test_averages_and_stdev_across_multiple_rounds(): void
+    {
+        $parser = new MtrRawParser('9.9.9.9'); // never seen below - no collapse in play
+        $parser->feed('x 1 1');
+        $parser->feed('h 1 8.8.8.8');
+        $parser->feed('p 1 1000 1'); // 1.0 ms
+        $parser->feed('x 1 2');
+        $parser->feed('p 1 3000 2'); // 3.0 ms
+
+        $snapshot = $parser->snapshot();
+        $hop = $snapshot['hops'][0];
+
+        $this->assertSame(2, $snapshot['rounds_done']);
+        $this->assertSame(2, $hop['sent']);
+        $this->assertSame(2, $hop['recv']);
+        $this->assertSame(1.0, $hop['best_ms']);
+        $this->assertSame(3.0, $hop['worst_ms']);
+        $this->assertSame(3.0, $hop['last_ms']);
+        $this->assertSame(2.0, $hop['avg_ms']);
+        $this->assertSame(1.0, $hop['stdev_ms']); // population stdev of {1.0, 3.0} = 1.0
+    }
+
+    /** @return array{rounds_done: int, hops: list<array<string, mixed>>} */
+    private function parseSample(): array
+    {
+        $parser = new MtrRawParser('1.1.1.1');
+        foreach (self::SAMPLE_CAPTURE as $line) {
+            $parser->feed($line);
+        }
+
+        return $parser->snapshot();
+    }
+}


### PR DESCRIPTION
Adds a live, MTR-style trace to the device inspector — a "Trace" button next to Web UI / Winbox / SSH that streams a hop-by-hop path from the MyMate server to the device's mgmt IP into a live table: per-hop loss %, sent, last/avg/best/worst/stdev latency, reverse-DNS names, color-coded loss, and a latency bar so a jump down the path is visible at a glance. Inspired by tools like `trippy`/classic `mtr`; kills the last reason our NOC was keeping The Dude around (right-click ping/trace).

How it works:

- **Engine**: the `mtr` binary in `--raw` machine-readable mode (`mtr --raw -b -i 1 -c N`), streamed line-by-line. `MtrRawParser` keeps per-hop running stats (Welford's online mean/variance — no sample buffers) and collapses mtr's trailing-target artifact (the destination answering at several TTLs while mtr hunts path length).
- **Job**: `RunTraceJob` on a new, isolated `trace` Horizon queue (a live table an operator forgot to close can never starve ping/poll workers). Snapshots go to cache once a second; a stop flag from the API kills the mtr process within 250 ms. `tries=1` — a dead trace surfaces as failed/stopped, never silently retried.
- **API**: `POST /devices/{device}/trace` (202 + run id, cache pre-seeded so the first poll can't race the worker), `GET .../trace/{runId}` (snapshot), `DELETE` (stop). Run ids are cross-checked against the device so one device's trace can't be read via another. Start/stop are exempt from the admin-writes gate via a documented allowlist — the target is locked to the device's own mgmt IP, so there's nothing for a read-only operator to break.
- **UI**: polls at 1 s while running; rounds picker (20/60/120), Stop / Run again, stops the server-side run on close/unmount. Dead hops keep their row (`* * *`) so TTLs never renumber.

Dependency: the `mtr` binary (`mtr-tiny` on Debian — its `mtr-packet` helper ships with cap_net_raw, so no root needed). Added to the Dockerfile and BUILD.md alongside fping.

Includes a pure-PHPUnit unit test for the raw-stream parser, fed with real captured `mtr --raw` output. Running in production on my ~26k-device install since yesterday; `npm ci && npx tsc --noEmit && npx vite build` clean at each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Note: this and #29 both add small blocks to `routes/api.php` and `config/horizon.php` - whichever lands second will need a trivial rebase.
